### PR TITLE
Add aspera support

### DIFF
--- a/python/enaDataGet.py
+++ b/python/enaDataGet.py
@@ -31,6 +31,8 @@ def set_parser():
     parser.add_argument('-i', '--index', action='store_true',
                         help="""Download CRAM index files with submitted CRAM files, if any (default is false).
                             This flag is ignored for fastq and sra format options. """)
+    parser.add_argument('-a', '--aspera', action='store_true',
+                        help='Use the aspera command line client to download, instead of FTP (default is false).')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     return parser
 
@@ -45,6 +47,7 @@ if __name__ == '__main__':
     fetch_wgs = args.wgs
     fetch_meta = args.meta
     fetch_index = args.index
+    aspera = args.aspera
 
     try:
         if utils.is_wgs_set(accession):
@@ -61,11 +64,11 @@ if __name__ == '__main__':
         elif utils.is_analysis(accession):
             if format is not None:
                 readGet.check_read_format(format)
-            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta)
+            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         elif utils.is_run(accession) or utils.is_experiment(accession):
             if format is not None:
                 readGet.check_read_format(format)
-            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta)
+            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         elif utils.is_assembly(accession):
             if format is not None:
                 assemblyGet.check_format(format)

--- a/python/readGet.py
+++ b/python/readGet.py
@@ -9,7 +9,7 @@ import argparse
 import utils
 
 def set_parser():
-    parser = argparse.ArgumentParser(prog='runGet',
+    parser = argparse.ArgumentParser(prog='readGet',
                             description='Download sequence data for a given INSDC run/experiment accession')
     parser.add_argument('accession', help='INSDC run/experiment accession to fetch')
     parser.add_argument('-f', '--format', default='submitted', choices=['submitted', 'fastq', 'sra'],
@@ -21,6 +21,8 @@ def set_parser():
     parser.add_argument('-i', '--index', action='store_true',
                         help="""Download CRAM index files with submitted CRAM files, if any (default is false).
                             This flag is ignored for fastq and sra format options""")
+    parser.add_argument('-a', '--aspera', action='store_true',
+                        help='Use the aspera command line client to download, instead of FTP (default is false).')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     return parser
 
@@ -35,21 +37,29 @@ def check_analysis_format(format):
         print 'Please select a valid format for this accession: ', utils.SUBMITTED_FORMAT
         sys.exit(1)
 
-def download_file_with_md5_check(file_url, dest_dir, md5):
-    print 'downloading file ', file_url
-    success = utils.get_ftp_file_with_md5_check(file_url, dest_dir, md5)
+def download_file_with_md5_check(file_url, dest_dir, md5, aspera):
+    print ('Downloading file with md5 check:', file_url)
+    success=False
+    if aspera:
+        success = utils.get_aspera_file_with_md5_check(file_url, dest_dir, md5)
+    else:
+        success = utils.get_ftp_file_with_md5_check('ftp://' + file_url, dest_dir, md5)
+        if not success:
+            success = utils.get_ftp_file_with_md5_check('ftp://' + file_url, dest_dir, md5)
     if not success:
-        success = utils.get_ftp_file_with_md5_check(file_url, dest_dir, md5)
-    if not success:
-        print 'Failed to download file '
+        print ('Failed to download file')
 
-def download_file(file_url, dest_dir):
-    print 'downloading file', file_url
-    success = utils.get_ftp_file(file_url, dest_dir)
+def download_file(file_url, dest_dir, aspera):
+    print ('Downloading file:', file_url)
+    success=False
+    if aspera:
+        success = utils.get_aspera_file(file_url, dest_dir)
+    else:
+        success = utils.get_ftp_file('ftp://' + file_url, dest_dir)
+        if not success:
+            success = utils.get_ftp_file('ftp://' + file_url, dest_dir)
     if not success:
-        success = utils.get_ftp_file(file_url, dest_dir)
-    if not success:
-        print 'Failed to download file '
+        print ('Failed to download file')
 
 def download_meta(accession, dest_dir):
     utils.download_record(dest_dir, accession, utils.XML_FORMAT)
@@ -66,7 +76,7 @@ def download_experiment_meta(run_accession, dest_dir):
         break
     download_meta(experiment_accession, dest_dir)
 
-def download_files(accession, format, dest_dir, fetch_index, fetch_meta):
+def download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera):
     if format is None:
         format = utils.SUBMITTED_FORMAT
     accession_dir = os.path.join(dest_dir, accession)
@@ -79,7 +89,7 @@ def download_files(accession, format, dest_dir, fetch_index, fetch_meta):
     if fetch_meta and utils.is_run(accession):
         download_experiment_meta(accession, accession_dir)
     # download data files
-    search_url = utils.get_file_search_query(accession, format, fetch_index)
+    search_url = utils.get_file_search_query(accession, format, fetch_index, aspera)
     temp_file = os.path.join(dest_dir, 'temp.txt')
     utils.download_report_from_portal(search_url, temp_file)
     f = open(temp_file)
@@ -106,10 +116,10 @@ def download_files(accession, format, dest_dir, fetch_index, fetch_meta):
             file_url = filelist[i]
             md5 = md5list[i]
             if file_url != '':
-                download_file_with_md5_check('ftp://' + file_url, target_dir, md5)
+                download_file_with_md5_check(file_url, target_dir, md5, aspera)
         for index_file in indexlist:
             if index_file != '':
-                download_file('ftp://' + index_file, target_dir)
+                download_file(index_file, target_dir, aspera)
 
 
 if __name__ == '__main__':
@@ -121,6 +131,7 @@ if __name__ == '__main__':
     dest_dir = args.dest
     fetch_meta = args.meta
     fetch_index = args.index
+    aspera = args.aspera
 
     if not utils.is_run(accession) and not utils.is_experiment(accession):
         print 'Error: Invalid accession. An INSDC run or experiment accession must be provided'
@@ -131,7 +142,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        download_files(accession, format, dest_dir, fetch_index, fetch_meta)
+        download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         print 'Download completed'
     except Exception:
         utils.print_error()

--- a/python/readGet.py
+++ b/python/readGet.py
@@ -1,5 +1,5 @@
 #
-# runGet.py
+# readGet.py
 #
 
 import os
@@ -38,7 +38,7 @@ def check_analysis_format(format):
         sys.exit(1)
 
 def download_file_with_md5_check(file_url, dest_dir, md5, aspera):
-    print ('Downloading file with md5 check:', file_url)
+    print 'Downloading file with md5 check:' + file_url
     success=False
     if aspera:
         success = utils.get_aspera_file_with_md5_check(file_url, dest_dir, md5)
@@ -47,10 +47,10 @@ def download_file_with_md5_check(file_url, dest_dir, md5, aspera):
         if not success:
             success = utils.get_ftp_file_with_md5_check('ftp://' + file_url, dest_dir, md5)
     if not success:
-        print ('Failed to download file')
+        print 'Failed to download file'
 
 def download_file(file_url, dest_dir, aspera):
-    print ('Downloading file:', file_url)
+    print 'Downloading file:' + file_url
     success=False
     if aspera:
         success = utils.get_aspera_file(file_url, dest_dir)
@@ -59,7 +59,7 @@ def download_file(file_url, dest_dir, aspera):
         if not success:
             success = utils.get_ftp_file('ftp://' + file_url, dest_dir)
     if not success:
-        print ('Failed to download file')
+        print 'Failed to download file'
 
 def download_meta(accession, dest_dir):
     utils.download_record(dest_dir, accession, utils.XML_FORMAT)

--- a/python/utils.py
+++ b/python/utils.py
@@ -82,7 +82,7 @@ ASPERA_LICENCE = '/path/to/aspera_dsa.openssh' # ascp licence file
 ASPERA_OPTIONS = '' # set any extra aspera options
 ASPERA_SPEED = '100M' # set aspera download speed
 
-MD5_BIN = 'md5sum' # can be 'md5' on some systems
+MD5_BIN = 'md5' # usually 'md5sum' on linux systems
 
 sequence_pattern_1 = re.compile('^[A-Z]{1}[0-9]{5}(\.[0-9]+)?$')
 sequence_pattern_2 = re.compile('^[A-Z]{2}[0-9]{6}(\.[0-9]+)?$')

--- a/python/utils.py
+++ b/python/utils.py
@@ -78,7 +78,8 @@ SRA_ASPERA_FIELD = 'sra_aspera'
 INDEX_ASPERA_FIELD = 'cram_index_aspera'
 
 ASPERA_BIN = 'ascp' # ascp binary
-ASPERA_LICENCE = '/path/to/aspera_dsa.openssh' # ascp licence file
+ASPERA_PRIVATE_KEY = '/path/to/aspera_dsa.openssh' # ascp private key file
+ASPERA_LICENSE = 'aspera-license' # ascp license file
 ASPERA_OPTIONS = '' # set any extra aspera options
 ASPERA_SPEED = '100M' # set aspera download speed
 
@@ -165,18 +166,24 @@ def get_accession_type(accession):
         return SEQUENCE
     return None
 
-def accession_format_allowed(accession, format):
+def accession_format_allowed(accession, format, aspera):
     if is_analysis(accession):
         return format == SUBMITTED_FORMAT
     if is_run(accession) or is_experiment(accession):
-        return format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_FIELD]
+        if aspera:
+            return format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_ASPERA_FIELD]
+        else:
+            return format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_FIELD]
     return format in [EMBL_FORMAT, FASTA_FORMAT]
 
-def group_format_allowed(group, format):
+def group_format_allowed(group, format, aspera):
     if group == ANALYSIS:
         return format == SUBMITTED_FORMAT
     if group == READ:
-        return format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_FIELD]
+        if aspera:
+            return format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_ASPERA_FIELD]
+        else:
+            return format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_FIELD]
     return format in [EMBL_FORMAT, FASTA_FORMAT]
 
 # assumption is that accession and format have already been vetted before this method is called
@@ -287,14 +294,14 @@ def asperaretrieve(url, dest_dir, dest_file):
     try:
         logdir=os.path.abspath(os.path.join(dest_dir, "logs"))
         create_dir(logdir)
-        aspera_line="{bin} -QT -L {logs} -l {speed} {aspera} -i {licence} era-fasp@{file} {outdir}"
+        aspera_line="{bin} -QT -L {logs} -l {speed} {aspera} -i {key} era-fasp@{file} {outdir}"
         aspera_line=aspera_line.format(
             bin=ASPERA_BIN,
             outdir=dest_dir,
             logs=logdir,
             file=url,
             aspera=ASPERA_OPTIONS,
-            licence=ASPERA_LICENCE,
+            key=ASPERA_PRIVATE_KEY,
             speed=ASPERA_SPEED,
         )
         print aspera_line

--- a/python/utils.py
+++ b/python/utils.py
@@ -72,6 +72,17 @@ FASTQ_MD5_FIELD = 'fastq_md5'
 SUBMITTED_MD5_FIELD = 'submitted_md5'
 SRA_MD5_FIELD = 'sra_md5'
 INDEX_MD5_FIELD = None
+FASTQ_ASPERA_FIELD = 'fastq_aspera'
+SUBMITTED_ASPERA_FIELD = 'submitted_aspera'
+SRA_ASPERA_FIELD = 'sra_aspera'
+INDEX_ASPERA_FIELD = 'cram_index_aspera'
+
+ASPERA_BIN = 'ascp' # ascp binary
+ASPERA_LICENCE = '/path/to/aspera_dsa.openssh' # ascp licence file
+ASPERA_OPTIONS = '' # set any extra aspera options
+ASPERA_SPEED = '100M' # set aspera download speed
+
+MD5_BIN = 'md5sum' # can be 'md5' on some systems
 
 sequence_pattern_1 = re.compile('^[A-Z]{1}[0-9]{5}(\.[0-9]+)?$')
 sequence_pattern_2 = re.compile('^[A-Z]{2}[0-9]{6}(\.[0-9]+)?$')
@@ -226,10 +237,20 @@ def get_ftp_file(ftp_url, dest_dir):
     except Exception:
         return False
 
+def get_aspera_file(aspera_url, dest_dir):
+    try:
+        filename = aspera_url.split('/')[-1]
+        dest_file = os.path.join(dest_dir, filename)
+        asperaretrieve(aspera_url, dest_dir, dest_file)
+        return True
+    except Exception:
+        return False
+
 def get_md5(filepath):
-    p = subprocess.Popen(['md5', filepath], stdout=subprocess.PIPE)
+    print 'Checksumming ' + filepath
+    p = subprocess.Popen([MD5_BIN, filepath], stdout=subprocess.PIPE)
     output, error = p.communicate()
-    return output.split('=')[-1].strip()
+    return re.split(r'\s|=', output)[0].strip()
 
 def get_ftp_file_with_md5_check(ftp_url, dest_dir, md5):
     try:
@@ -240,6 +261,44 @@ def get_ftp_file_with_md5_check(ftp_url, dest_dir, md5):
             print 'MD5 mismatch for downloaded file ' + filepath + '. Deleting file'
             os.remove(dest_file)
             return False
+        return True
+    except Exception:
+        return False
+
+def get_aspera_file_with_md5_check(aspera_url, dest_dir, md5):
+    try:
+        filename = aspera_url.split('/')[-1]
+        dest_file = os.path.join(dest_dir, filename)
+        success = asperaretrieve(aspera_url, dest_dir, dest_file)
+        if success:
+            generated_md5 = get_md5(dest_file)
+            if md5 != generated_md5:
+                print 'MD5 mismatch for downloaded file ' + filepath + '. Deleting file'
+                print 'generated md5 ' + generated_md5
+                print 'expected md5 ' + md5
+                os.remove(dest_file)
+                return False
+            return True
+        return success
+    except Exception:
+        return False
+
+def asperaretrieve(url, dest_dir, dest_file):
+    try:
+        logdir=os.path.abspath(os.path.join(dest_dir, "logs"))
+        create_dir(logdir)
+        aspera_line="{bin} -QT -L {logs} -l {speed} {aspera} -i {licence} era-fasp@{file} {outdir}"
+        aspera_line=aspera_line.format(
+            bin=ASPERA_BIN,
+            outdir=dest_dir,
+            logs=logdir,
+            file=url,
+            aspera=ASPERA_OPTIONS,
+            licence=ASPERA_LICENCE,
+            speed=ASPERA_SPEED,
+        )
+        print aspera_line
+        subprocess.call(aspera_line, shell=True) # this blocks so we're fine to wait and return True
         return True
     except Exception:
         return False
@@ -277,16 +336,31 @@ def get_accession_query(accession):
     query += '"'
     return query
 
-def get_file_fields(accession, format, fetch_index):
+def get_file_fields(accession, format, fetch_index, aspera):
+    if aspera:
+        fields = get_aspera_file_fields(accession, format, fetch_index)
+    else:
+        fields = 'fields='
+        if format == SRA_FORMAT:
+            fields += SRA_FIELD + ',' + SRA_MD5_FIELD
+        elif format == FASTQ_FORMAT:
+            fields += FASTQ_FIELD + ',' + FASTQ_MD5_FIELD
+        else:
+            fields += SUBMITTED_FIELD + ',' + SUBMITTED_MD5_FIELD
+            if fetch_index and not is_analysis(accession):
+                fields += ',' + INDEX_FIELD
+    return fields
+
+def get_aspera_file_fields(accession, format, fetch_index):
     fields = 'fields='
     if format == SRA_FORMAT:
-        fields += SRA_FIELD + ',' + SRA_MD5_FIELD
+        fields += SRA_ASPERA_FIELD + ',' + SRA_MD5_FIELD
     elif format == FASTQ_FORMAT:
-        fields += FASTQ_FIELD + ',' + FASTQ_MD5_FIELD
+        fields += FASTQ_ASPERA_FIELD + ',' + FASTQ_MD5_FIELD
     else:
-        fields += SUBMITTED_FIELD + ',' + SUBMITTED_MD5_FIELD
+        fields += SUBMITTED_ASPERA_FIELD + ',' + SUBMITTED_MD5_FIELD
         if fetch_index and not is_analysis(accession):
-            fields += ',' + INDEX_FIELD
+            fields += ',' + INDEX_ASPERA_FIELD
     return fields
 
 def get_result(accession):
@@ -295,9 +369,8 @@ def get_result(accession):
     else:  # is_analysis(accession)
         return ANALYSIS_RESULT
 
-def get_file_search_query(accession, format, fetch_index):
-    return PORTAL_SEARCH_BASE + get_accession_query(accession) + '&' \
-        + get_result(accession) + '&' + get_file_fields(accession, format, fetch_index) + '&limit=0'
+def get_file_search_query(accession, format, fetch_index, aspera):
+    return PORTAL_SEARCH_BASE + get_accession_query(accession) + '&' + get_result(accession) + '&' + get_file_fields(accession, format, fetch_index, aspera) + '&limit=0'
 
 def parse_file_search_result_line(line, accession, format, fetch_index):
     cols = line.split('\t')

--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -31,6 +31,8 @@ def set_parser():
     parser.add_argument('-i', '--index', action='store_true',
                         help="""Download CRAM index files with submitted CRAM files, if any (default is false).
                             This flag is ignored for fastq and sra format options. """)
+    parser.add_argument('-a', '--aspera', action='store_true',
+                        help='Use the aspera command line client to download, instead of FTP (default is false).')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     return parser
 
@@ -45,6 +47,7 @@ if __name__ == '__main__':
     fetch_wgs = args.wgs
     fetch_meta = args.meta
     fetch_index = args.index
+    aspera = args.aspera
 
     try:
         if utils.is_wgs_set(accession):
@@ -61,11 +64,11 @@ if __name__ == '__main__':
         elif utils.is_analysis(accession):
             if format is not None:
                 readGet.check_read_format(format)
-            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta)
+            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         elif utils.is_run(accession) or utils.is_experiment(accession):
             if format is not None:
                 readGet.check_read_format(format)
-            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta)
+            readGet.download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         elif utils.is_assembly(accession):
             if format is not None:
                 assemblyGet.check_format(format)

--- a/python3/enaGroupGet.py
+++ b/python3/enaGroupGet.py
@@ -32,11 +32,14 @@ def set_parser():
     parser.add_argument('-i', '--index', action='store_true',
                         help="""Download CRAM index files with submitted CRAM files, if any (default is false).
                             This flag is ignored for fastq and sra format options. """)
+    parser.add_argument('-a', '--aspera', action='store_true',
+                        help='Use the aspera command line client to download, instead of FTP (default is false).')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     return parser
 
 def download_report(group, result, accession, temp_file):
     search_url = utils.get_group_search_query(group, result, accession)
+    print (search_url)
     response = utils.get_report_from_portal(search_url)
     f = open(temp_file, 'wb')
     for line in response:
@@ -44,18 +47,22 @@ def download_report(group, result, accession, temp_file):
     f.flush()
     f.close()
 
-def download_data(group, data_accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index):
+def download_data(group, data_accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index, aspera):
     if group == utils.WGS:
-        print ('fetching ' + data_accession[:6])
+        print ('Fetching ' + data_accession[:6])
+        if aspera:
+            print ('Aspera not supported for WGS data. Using FTP...')
         sequenceGet.download_wgs(group_dir, data_accession[:6], format)
     else:
-        print ('fetching ' + data_accession)
+        print ('Fetching ' + data_accession)
         if group == utils.ASSEMBLY:
+            if aspera:
+                print ('Aspera not supported for assembly data. Using FTP...')
             assemblyGet.download_assembly(group_dir, data_accession, format, fetch_wgs, True)
         elif group in [utils.READ, utils.ANALYSIS]:
-            readGet.download_files(data_accession, format, group_dir, fetch_index, fetch_meta)
+            readGet.download_files(data_accession, format, group_dir, fetch_index, fetch_meta, aspera)
 
-def download_data_group(group, accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index):
+def download_data_group(group, accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index, aspera):
     temp_file = os.path.join(group_dir, accession + '_temp.txt')
     download_report(group, utils.get_group_result(group), accession, temp_file)
     f = open(temp_file)
@@ -65,7 +72,7 @@ def download_data_group(group, accession, format, group_dir, fetch_wgs, fetch_me
             header = False
             continue
         data_accession = line.strip()
-        download_data(group, data_accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index)
+        download_data(group, data_accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index, aspera)
     f.close()
     os.remove(temp_file)
 
@@ -102,14 +109,15 @@ def download_sequence_group(accession, format, study_dir):
     f.close()
     os.remove(temp_file)
 
-def download_group(accession, group, format, dest_dir, fetch_wgs, fetch_meta, fetch_index):
+def download_group(accession, group, format, dest_dir, fetch_wgs, fetch_meta, fetch_index, aspera):
     group_dir = os.path.join(dest_dir, accession)
     utils.create_dir(group_dir)
     if group == utils.SEQUENCE:
+        if aspera:
+            print ('Aspera not supported for sequence downloads. Using FTP...')
         download_sequence_group(accession, format, group_dir)
     else:
-        download_data_group(group, accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index)
-
+        download_data_group(group, accession, format, group_dir, fetch_wgs, fetch_meta, fetch_index, aspera)
 
 if __name__ == '__main__':
     parser = set_parser()
@@ -122,6 +130,7 @@ if __name__ == '__main__':
     fetch_wgs = args.wgs
     fetch_meta = args.meta
     fetch_index = args.index
+    aspera = args.aspera
 
     if not utils.is_available(accession):
         print ('Study/sample does not exist or is not available for accession provided')
@@ -137,7 +146,7 @@ if __name__ == '__main__':
             format = utils.SUBMITTED_FORMAT
         else:
             format = utils.EMBL_FORMAT
-    elif not utils.group_format_allowed(group, format):
+    elif not utils.group_format_allowed(group, format, aspera):
         print ('Illegal group and format combination provided.  Allowed:')
         print ('sequence, assembly and wgs groups: embl and fasta formats')
         print ('read group: submitted, fastq and sra formats')
@@ -145,7 +154,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        download_group(accession, group, format, dest_dir, fetch_wgs, fetch_meta, fetch_index)
+        download_group(accession, group, format, dest_dir, fetch_wgs, fetch_meta, fetch_index, aspera)
         print ('Download completed')
     except Exception:
         utils.print_error()

--- a/python3/readGet.py
+++ b/python3/readGet.py
@@ -1,5 +1,5 @@
 #
-# runGet.py
+# readGet.py
 #
 
 import os
@@ -9,7 +9,7 @@ import argparse
 import utils
 
 def set_parser():
-    parser = argparse.ArgumentParser(prog='runGet',
+    parser = argparse.ArgumentParser(prog='readGet',
                             description='Download sequence data for a given INSDC run/experiment accession')
     parser.add_argument('accession', help='INSDC run/experiment accession to fetch')
     parser.add_argument('-f', '--format', default='submitted', choices=['submitted', 'fastq', 'sra'],
@@ -38,7 +38,7 @@ def check_analysis_format(format):
         sys.exit(1)
 
 def download_file_with_md5_check(file_url, dest_dir, md5, aspera):
-    print ('downloading file ', file_url)
+    print ('Downloading file with md5 check', file_url)
     if aspera:
         success = utils.get_aspera_file_with_md5_check(file_url, dest_dir, md5)
     else:
@@ -49,7 +49,7 @@ def download_file_with_md5_check(file_url, dest_dir, md5, aspera):
         print ('Failed to download file')
 
 def download_file(file_url, dest_dir, aspera):
-    print ('downloading file', file_url)
+    print ('Downloading file', file_url)
     if aspera:
         success = utils.get_aspera_file(file_url, dest_dir)
     else:
@@ -118,7 +118,6 @@ def download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         for index_file in indexlist:
             if index_file != '':
                 download_file(index_file, target_dir, aspera)
-
 
 if __name__ == '__main__':
     parser = set_parser()

--- a/python3/readGet.py
+++ b/python3/readGet.py
@@ -21,6 +21,8 @@ def set_parser():
     parser.add_argument('-i', '--index', action='store_true',
                         help="""Download CRAM index files with submitted CRAM files, if any (default is false).
                             This flag is ignored for fastq and sra format options""")
+    parser.add_argument('-a', '--aspera', action='store_true',
+                        help='Use the aspera command line client to download, instead of FTP (default is false).')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     return parser
 
@@ -35,19 +37,25 @@ def check_analysis_format(format):
         print ('Please select a valid format for this accession: ', utils.SUBMITTED_FORMAT)
         sys.exit(1)
 
-def download_file_with_md5_check(file_url, dest_dir, md5):
+def download_file_with_md5_check(file_url, dest_dir, md5, aspera):
     print ('downloading file ', file_url)
-    success = utils.get_ftp_file_with_md5_check(file_url, dest_dir, md5)
-    if not success:
-        success = utils.get_ftp_file_with_md5_check(file_url, dest_dir, md5)
+    if aspera:
+        success = utils.get_aspera_file_with_md5_check(file_url, dest_dir, md5)
+    else:
+        success = utils.get_ftp_file_with_md5_check('ftp://' + file_url, dest_dir, md5)
+        if not success:
+            success = utils.get_ftp_file_with_md5_check('ftp://' + file_url, dest_dir, md5)
     if not success:
         print ('Failed to download file')
 
-def download_file(file_url, dest_dir):
+def download_file(file_url, dest_dir, aspera):
     print ('downloading file', file_url)
-    success = utils.get_ftp_file(file_url, dest_dir)
-    if not success:
-        success = utils.get_ftp_file(file_url, dest_dir)
+    if aspera:
+        success = utils.get_aspera_file(file_url, dest_dir)
+    else:
+        success = utils.get_ftp_file('ftp://' + file_url, dest_dir)
+        if not success:
+            success = utils.get_ftp_file('ftp://' + file_url, dest_dir)
     if not success:
         print ('Failed to download file')
 
@@ -66,7 +74,7 @@ def download_experiment_meta(run_accession, dest_dir):
         break
     download_meta(experiment_accession, dest_dir)
 
-def download_files(accession, format, dest_dir, fetch_index, fetch_meta):
+def download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera):
     if format is None:
         format = utils.SUBMITTED_FORMAT
     accession_dir = os.path.join(dest_dir, accession)
@@ -79,7 +87,7 @@ def download_files(accession, format, dest_dir, fetch_index, fetch_meta):
     if fetch_meta and utils.is_run(accession):
         download_experiment_meta(accession, accession_dir)
     # download data files
-    search_url = utils.get_file_search_query(accession, format, fetch_index)
+    search_url = utils.get_file_search_query(accession, format, fetch_index, aspera)
     temp_file = os.path.join(dest_dir, 'temp.txt')
     utils.download_report_from_portal(search_url, temp_file)
     f = open(temp_file)
@@ -106,10 +114,10 @@ def download_files(accession, format, dest_dir, fetch_index, fetch_meta):
             file_url = filelist[i]
             md5 = md5list[i]
             if file_url != '':
-                download_file_with_md5_check('ftp://' + file_url, target_dir, md5)
+                download_file_with_md5_check(file_url, target_dir, md5, aspera)
         for index_file in indexlist:
             if index_file != '':
-                download_file('ftp://' + index_file, target_dir)
+                download_file(index_file, target_dir, aspera)
 
 
 if __name__ == '__main__':
@@ -121,6 +129,7 @@ if __name__ == '__main__':
     dest_dir = args.dest
     fetch_meta = args.meta
     fetch_index = args.index
+    aspera = args.aspera
 
     if not utils.is_run(accession) and not utils.is_experiment(accession):
         print ('Error: Invalid accession. An INSDC run or experiment accession must be provided')
@@ -131,7 +140,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        download_files(accession, format, dest_dir, fetch_index, fetch_meta)
+        download_files(accession, format, dest_dir, fetch_index, fetch_meta, aspera)
         print ('Download completed')
     except Exception:
         utils.print_error()

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -83,7 +83,7 @@ ASPERA_LICENCE = '/path/to/aspera_dsa.openssh' # ascp licence file
 ASPERA_OPTIONS = '' # set any extra aspera options
 ASPERA_SPEED = '100M' # set aspera download speed
 
-MD5_BIN = 'md5sum' # can be 'md5' on some systems
+MD5_BIN = 'md5' # usually 'md5sum' on linux systems
 
 sequence_pattern_1 = re.compile('^[A-Z]{1}[0-9]{5}(\.[0-9]+)?$')
 sequence_pattern_2 = re.compile('^[A-Z]{2}[0-9]{6}(\.[0-9]+)?$')


### PR DESCRIPTION
I've added support for the ascp command line tool to download files through readGet and enaDataGet (for sequence and read data). Users will need to specify the location of ascp and licence file through the utils.py module.

I've also added support for switching md5 to md5sum, and subsequently fixed the md5 summing output processing.

Cheers!