### PR TITLE
Fix format check for sequence data

### DIFF
--- a/python/sequenceGet.py
+++ b/python/sequenceGet.py
@@ -70,6 +70,6 @@ def download_unversioned_wgs(dest_dir, accession, output_format):
 
 def check_format(output_format):
     allowed_formats = [utils.EMBL_FORMAT, utils.FASTA_FORMAT, utils.MASTER_FORMAT]
-    if format not in allowed_formats:
+    if output_format not in allowed_formats:
         sys.stderr.write('Please select a valid format for this accession: {0}\n'.format(allowed_formats))
         sys.exit(1)


### PR DESCRIPTION
The format check was broken for sequence data downloads in the python 2.x code. This should bring it in line with the 3.x code.