### PR TITLE
Implement a progress output handler for ftp and aspera downloads

### DIFF
--- a/python/assemblyGet.py
+++ b/python/assemblyGet.py
@@ -93,7 +93,7 @@ def download_sequences(sequence_report, assembly_dir, output_format, quiet):
     download_sequence_set(unplaced_list, UNPLACED, assembly_dir, output_format, quiet)
     download_sequence_set(patch_list, PATCH, assembly_dir, output_format, quiet)
 
-def download_assembly(dest_dir, accession, output_format, fetch_wgs, quiet=False):
+def download_assembly(dest_dir, accession, output_format, fetch_wgs, quiet=False, handler=None):
     if output_format is None:
         output_format = utils.EMBL_FORMAT
     assembly_dir = os.path.join(dest_dir, accession)
@@ -106,12 +106,12 @@ def download_assembly(dest_dir, accession, output_format, fetch_wgs, quiet=False
     has_sequence_report = False
     # download sequence report
     if sequence_report is not None:
-        has_sequence_report = utils.get_ftp_file(sequence_report, assembly_dir)
+        has_sequence_report = utils.get_ftp_file(sequence_report, assembly_dir, handler)
     # download wgs set if needed
     if wgs_set is not None and fetch_wgs:
         if not quiet:
             print 'fetching wgs set'
-        sequenceGet.download_wgs(assembly_dir, wgs_set, output_format)
+        sequenceGet.download_wgs(assembly_dir, wgs_set, output_format, handler)
     # parse sequence report and download sequences
     if has_sequence_report:
         download_sequences(sequence_report.split('/')[-1], assembly_dir, output_format, quiet)

--- a/python/enaDataGet.py
+++ b/python/enaDataGet.py
@@ -76,28 +76,33 @@ if __name__ == '__main__':
 
     try:
         if utils.is_wgs_set(accession):
+            print("Downloading WGS set")
             if output_format is not None:
                 sequenceGet.check_format(output_format)
-            sequenceGet.download_wgs(dest_dir, accession, output_format)
+            sequenceGet.download_wgs(dest_dir, accession, output_format, handler)
         elif not utils.is_available(accession):
             sys.stderr.write('ERROR: Record does not exist or is not available for accession provided\n')
             sys.exit(1)
         elif utils.is_sequence(accession):
+            print("Downloading sequence(s)")
             if output_format is not None:
                 sequenceGet.check_format(output_format)
-            sequenceGet.download_sequence(dest_dir, accession, output_format)
+            sequenceGet.download_sequence(dest_dir, accession, output_format, handler)
         elif utils.is_analysis(accession):
+            print("Downloading analysis")
             if output_format is not None:
                 readGet.check_read_format(output_format)
             readGet.download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, aspera, handler)
         elif utils.is_run(accession) or utils.is_experiment(accession):
+            print("Downloading reads")
             if output_format is not None:
                 readGet.check_read_format(output_format)
-            readGet.download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, aspera)
+            readGet.download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, aspera, handler)
         elif utils.is_assembly(accession):
+            print("Downloading assembly")
             if output_format is not None:
                 assemblyGet.check_format(output_format)
-            assemblyGet.download_assembly(dest_dir, accession, output_format, fetch_wgs)
+            assemblyGet.download_assembly(dest_dir, accession, output_format, fetch_wgs, handler)
         else:
             sys.stderr.write('ERROR: Invalid accession provided\n')
             sys.exit(1)

--- a/python/enaDataGet.py
+++ b/python/enaDataGet.py
@@ -50,7 +50,7 @@ def set_parser():
     parser.add_argument('-as', '--aspera-settings', default=None,
                     help="""Use the provided settings file, will otherwise check
                         for environment variable or default settings file location.""")
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4.1')
     return parser
 
 

--- a/python/enaGroupGet.py
+++ b/python/enaGroupGet.py
@@ -54,7 +54,7 @@ def set_parser():
                         for environment variable or default settings file location.""")
     parser.add_argument('-t', '--subtree', action='store_true',
                         help='Include subordinate taxa (taxon subtree) when querying with NCBI tax ID (default is false)')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4.1')
     return parser
 
 def download_report(group, result, accession, temp_file, subtree):

--- a/python/sequenceGet.py
+++ b/python/sequenceGet.py
@@ -26,44 +26,44 @@ def append_record(dest_file, accession, output_format):
     url = utils.get_record_url(accession, output_format)
     return utils.append_record(url, dest_file)
 
-def download_sequence(dest_dir, accession, output_format):
+def download_sequence(dest_dir, accession, output_format, handler=None):
     if output_format is None:
         output_format = utils.EMBL_FORMAT
-    success = utils.download_record(dest_dir, accession, output_format)
+    success = utils.download_record(dest_dir, accession, output_format, handler)
     if not success:
         print 'Unable to fetch file for {0}, format {1}'.format(accession, output_format)
     return success
 
-def download_wgs(dest_dir, accession, output_format):
+def download_wgs(dest_dir, accession, output_format, handler=None):
     if utils.is_unversioned_wgs_set(accession):
-        return download_unversioned_wgs(dest_dir, accession, output_format)
+        return download_unversioned_wgs(dest_dir, accession, output_format, handler)
     else:
-        return download_versioned_wgs(dest_dir, accession, output_format)
+        return download_versioned_wgs(dest_dir, accession, output_format, handler)
 
-def download_versioned_wgs(dest_dir, accession, output_format):
+def download_versioned_wgs(dest_dir, accession, output_format, handler=None):
     prefix = accession[:6]
     if output_format is None:
         output_format = utils.EMBL_FORMAT
     public_set_url = utils.get_wgs_ftp_url(prefix, utils.PUBLIC, output_format)
     supp_set_url = utils.get_wgs_ftp_url(prefix, utils.SUPPRESSED, output_format)
-    success = utils.get_ftp_file(public_set_url, dest_dir)
+    success = utils.get_ftp_file(public_set_url, dest_dir, handler)
     if not success:
-        success = utils.get_ftp_file(supp_set_url, dest_dir)
+        success = utils.get_ftp_file(supp_set_url, dest_dir, handler)
     if not success:
         print 'No WGS set file available for {0}, format {1}'.format(accession, output_format)
         print 'Please contact ENA (datasubs@ebi.ac.uk) if you feel this set should be available'
 
-def download_unversioned_wgs(dest_dir, accession, output_format):
+def download_unversioned_wgs(dest_dir, accession, output_format, handler=None):
     prefix = accession[:4]
     if output_format is None:
         output_format = utils.EMBL_FORMAT
     public_set_url = utils.get_nonversioned_wgs_ftp_url(prefix, utils.PUBLIC, output_format)
     if public_set_url is not None:
-        utils.get_ftp_file(public_set_url, dest_dir)
+        utils.get_ftp_file(public_set_url, dest_dir, handler)
     else:
         supp_set_url = utils.get_nonversioned_wgs_ftp_url(prefix, utils.SUPPRESSED, output_format)
         if supp_set_url is not None:
-            utils.get_ftp_file(supp_set_url, dest_dir)
+            utils.get_ftp_file(supp_set_url, dest_dir, handler)
         else:
             print 'No WGS set file available for {0}, format {1}'.format(accession, output_format)
             print 'Please contact ENA (datasubs@ebi.ac.uk) if you feel this set should be available'

--- a/python/utils.py
+++ b/python/utils.py
@@ -409,7 +409,6 @@ def asperaretrieve(url, dest_dir, dest_file, handler=None):
             key=ASPERA_PRIVATE_KEY,
             speed=ASPERA_SPEED,
         )
-#        _do_aspera_transfer(aspera_line, handler)
         _do_aspera_pexpect(aspera_line, handler)
         return True
     except Exception as e:
@@ -457,7 +456,7 @@ def _do_aspera_pexpect(cmd, handler):
                         if handler and callable(handler):
                             handler(json.dumps(output))
                         else:
-                            sys.stdout.write("%s%% transferred, %s, %s\n" % (output["pct_completed"], output["bytes_transferred"], output["transfer_rate"])),
+                            sys.stdout.write("%s%% transferred, %s, %s\n" % (output["pct_completed"], output["bytes_transferred"], output["transfer_rate"]))
     thread.close()
 
 def _do_aspera_transfer(cmd, handler):

--- a/python/utils.py
+++ b/python/utils.py
@@ -27,6 +27,7 @@ import urllib
 import urllib2
 import pexpect
 import time
+import shlex
 from datetime import datetime
 import xml.etree.ElementTree as ElementTree
 from subprocess import call, Popen, PIPE
@@ -414,7 +415,7 @@ def asperaretrieve(url, dest_dir, dest_file, handler=None):
         return False
 
 def _do_aspera_transfer(cmd, handler):
-    p = Popen(cmd, stdout=PIPE, bufsize=1)
+    p = Popen(shlex.split(cmd), stdout=PIPE, bufsize=1)
     with p.stdout:
         for line in iter(p.stdout.readline, b''):
             if handler and callable(handler):

--- a/python/utils.py
+++ b/python/utils.py
@@ -22,13 +22,13 @@ import ftplib
 import hashlib
 import re
 import os
-import subprocess
 import sys
 import urllib
 import urllib2
 import pexpect
 from datetime import datetime
 import xml.etree.ElementTree as ElementTree
+from subprocess import call, Popen, PIPE
 
 from ConfigParser import SafeConfigParser
 
@@ -386,7 +386,7 @@ def set_aspera(aspera_filepath):
             aspera = False
     return aspera
 
-def asperaretrieve(url, dest_dir, dest_file):
+def asperaretrieve(url, dest_dir, dest_file, handler=None):
     try:
         if not os.path.exists(ASPERA_BIN) or not os.path.exists(ASPERA_PRIVATE_KEY):
             raise FileNotFoundError('Aspera not available. Check your ascp binary path and your private key file is specified correctly')
@@ -402,101 +402,24 @@ def asperaretrieve(url, dest_dir, dest_file):
             key=ASPERA_PRIVATE_KEY,
             speed=ASPERA_SPEED,
         )
-        #print aspera_line
+        #sys.stdout.write(aspera_line)
         #subprocess.call(aspera_line, shell=True) # this blocks so we're fine to wait and return True
-        _do_aspera_transfer(aspera_line)
+        _do_aspera_transfer(aspera_line, handler)
         return True
     except Exception as e:
         sys.stderr.write("Error with Aspera transfer: {0}\n".format(e))
         return False
 
-def _do_aspera_transfer(cmd):
-    try:
-        sub_id = base64.b64encode(cmd)
-        thread = pexpect.spawn(cmd, timeout=None)
-        #thread.expect(["assword:", pexpect.EOF])
-        #thread.sendline(password)
-
-        cpl = thread.compile_pattern_list([pexpect.EOF, '(.+)'])
-
-        while True:
-            i = thread.expect_list(cpl, timeout=None)
-            if i == 0:  # EOF! Possible error point if encountered before transfer completion
-                print("Process termination - check exit status!")
-                break
-            elif i == 1:
-                pexp_match = thread.match.group(1)
-                prev_file = ''
-                tokens_to_match = ["Mb/s"]
-                units_to_match = ["KB", "MB"]
-                time_units = ['d', 'h', 'm', 's']
-                end_of_transfer = False
-
-                if all(tm in pexp_match.decode("utf-8") for tm in tokens_to_match):
-                    fields = {
-                        "transfer_status": "transferring",
-                        "current_time": datetime.now().strftime("%d-%m-%Y %H:%M:%S")
-                    }
-
-                    tokens = pexp_match.decode("utf-8").split(" ")
-
-                    #lg.log(tokens, level=Loglvl.INFO, type=Logtype.FILE)
-
-                    for token in tokens:
-                        if not token == '':
-                            if "file" in token:
-                                fields['file_path'] = token.split('=')[-1]
-                                if prev_file != fields['file_path']:
-                                    k = k + 1
-                                prev_file == fields['file_path']
-                            elif '%' in token:
-                                pct = float((token.rstrip("%")))
-                                # pct = (1/len(file_path) * pct) + (k * 1/len(file_path) * 100)
-                                fields['pct_completed'] = pct
-                                # flag end of transfer
-                                print(str(pct) + '% transfered')
-                                if token.rstrip("%") == 100:
-                                    end_of_transfer = True
-                            elif any(um in token for um in units_to_match):
-                                fields['amt_transferred'] = token
-                            elif "Mb/s" in token or "Mbps" in token:
-                                t = token[:-4]
-                                if '=' in t:
-                                    fields['transfer_rate'] = t[t.find('=') + 1:]
-                                else:
-                                    fields['transfer_rate'] = t
-                            elif "status" in token:
-                                fields['transfer_status'] = token.split('=')[-1]
-                            elif "rate" in token:
-                                fields['transfer_rate'] = token.split('=')[-1]
-                            elif "elapsed" in token:
-                                fields['elapsed_time'] = token.split('=')[-1]
-                            elif "loss" in token:
-                                fields['bytes_lost'] = token.split('=')[-1]
-                            elif "size" in token:
-                                fields['file_size_bytes'] = token.split('=')[-1]
-
-                            elif "ETA" in token:
-                                eta = tokens[-2]
-                                estimated_completion = ""
-                                eta_split = eta.split(":")
-                                t_u = time_units[-len(eta_split):]
-                                for indx, eta_token in enumerate(eta.split(":")):
-                                    if eta_token == "00":
-                                        continue
-                                    estimated_completion += eta_token + t_u[indx] + " "
-                                fields['estimated_completion'] = estimated_completion
-
-        kwargs = dict(target_id=sub_id, completed_on=datetime.now())
-        #Submission().save_record(dict(), **kwargs)
-        # close thread
-        thread.close()
-        print 'Aspera Transfer completed'
-
-    except OSError:
-        print "Error"
-    finally:
-        pass
+def _do_aspera_transfer(cmd, handler):
+    p = Popen(cmd, stdout=PIPE, bufsize=1)
+    with p.stdout:
+        for line in iter(p.stdout.readline, b''):
+            if handler and callable(handler):
+                handler(line)
+            else:
+                print line,
+    p.wait()
+    pass
 
 def get_wgs_file_ext(output_format):
     if output_format == EMBL_FORMAT:

--- a/python3/assemblyGet.py
+++ b/python3/assemblyGet.py
@@ -94,7 +94,7 @@ def download_sequences(sequence_report, assembly_dir, output_format, quiet):
     download_sequence_set(unplaced_list, UNPLACED, assembly_dir, output_format, quiet)
     download_sequence_set(patch_list, PATCH, assembly_dir, output_format, quiet)
 
-def download_assembly(dest_dir, accession, output_format, fetch_wgs, quiet=False):
+def download_assembly(dest_dir, accession, output_format, fetch_wgs, quiet=False, handler=None):
     if output_format is None:
         output_format = utils.EMBL_FORMAT
     assembly_dir = os.path.join(dest_dir, accession)
@@ -107,12 +107,12 @@ def download_assembly(dest_dir, accession, output_format, fetch_wgs, quiet=False
     has_sequence_report = False
     # download sequence report
     if sequence_report is not None:
-        has_sequence_report = utils.get_ftp_file(sequence_report, assembly_dir)
+        has_sequence_report = utils.get_ftp_file(sequence_report, assembly_dir, handler)
     # download wgs set if needed
     if wgs_set is not None and fetch_wgs:
         if not quiet:
             print ('fetching wgs set')
-        sequenceGet.download_wgs(assembly_dir, wgs_set, output_format)
+        sequenceGet.download_wgs(assembly_dir, wgs_set, output_format, handler)
     # parse sequence report and download sequences
     if has_sequence_report:
         download_sequences(sequence_report.split('/')[-1], assembly_dir, output_format, quiet)

--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -50,7 +50,7 @@ def set_parser():
     parser.add_argument('-as', '--aspera-settings', default=None,
                     help="""Use the provided settings file, will otherwise check
                         for environment variable or default settings file location.""")
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4.1')
     return parser
 
 
@@ -69,7 +69,7 @@ if __name__ == '__main__':
 
     if aspera or aspera_settings is not None:
         aspera = utils.set_aspera(aspera_settings)
-    
+
     try:
         if utils.is_wgs_set(accession):
             if output_format is not None:

--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -78,14 +78,14 @@ if __name__ == '__main__':
         if utils.is_wgs_set(accession):
             if output_format is not None:
                 sequenceGet.check_format(output_format)
-            sequenceGet.download_wgs(dest_dir, accession, output_format)
+            sequenceGet.download_wgs(dest_dir, accession, output_format, handler)
         elif not utils.is_available(accession):
             sys.stderr.write('ERROR: Record does not exist or is not available for accession provided\n')
             sys.exit(1)
         elif utils.is_sequence(accession):
             if output_format is not None:
                 sequenceGet.check_format(output_format)
-            sequenceGet.download_sequence(dest_dir, accession, output_format)
+            sequenceGet.download_sequence(dest_dir, accession, output_format, handler)
         elif utils.is_analysis(accession):
             if output_format is not None:
                 readGet.check_read_format(output_format)
@@ -97,7 +97,7 @@ if __name__ == '__main__':
         elif utils.is_assembly(accession):
             if output_format is not None:
                 assemblyGet.check_format(output_format)
-            assemblyGet.download_assembly(dest_dir, accession, output_format, fetch_wgs)
+            assemblyGet.download_assembly(dest_dir, accession, output_format, fetch_wgs, handler)
         else:
             sys.stderr.write('ERROR: Invalid accession provided\n')
             sys.exit(1)

--- a/python3/enaGroupGet.py
+++ b/python3/enaGroupGet.py
@@ -54,7 +54,7 @@ def set_parser():
                         for environment variable or default settings file location.""")
     parser.add_argument('-t', '--subtree', action='store_true',
                         help='Include subordinate taxa (taxon subtree) when querying with NCBI tax ID (default is false)')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.4.1')
     return parser
 
 def download_report(group, result, accession, temp_file, subtree):

--- a/python3/sequenceGet.py
+++ b/python3/sequenceGet.py
@@ -27,43 +27,43 @@ def append_record(dest_file, accession, output_format):
     url = utils.get_record_url(accession, output_format)
     return utils.append_record(url, dest_file)
 
-def download_sequence(dest_dir, accession, output_format):
+def download_sequence(dest_dir, accession, output_format, handler=None):
     if output_format is None:
         output_format = utils.EMBL_FORMAT
-    success = utils.download_record(dest_dir, accession, output_format)
+    success = utils.download_record(dest_dir, accession, output_format, handler)
     if not success:
         print ('Unable to fetch file for {0}, format {1}'.format(accession, output_format))
 
-def download_wgs(dest_dir, accession, output_format):
+def download_wgs(dest_dir, accession, output_format, handler=None):
     if utils.is_unversioned_wgs_set(accession):
-        return download_unversioned_wgs(dest_dir, accession, output_format)
+        return download_unversioned_wgs(dest_dir, accession, output_format, handler)
     else:
-        return download_versioned_wgs(dest_dir, accession, output_format)
+        return download_versioned_wgs(dest_dir, accession, output_format, handler)
 
-def download_versioned_wgs(dest_dir, accession, output_format):
+def download_versioned_wgs(dest_dir, accession, output_format, handler=None):
     prefix = accession[:6]
     if output_format is None:
         output_format = utils.EMBL_FORMAT
     public_set_url = utils.get_wgs_ftp_url(prefix, utils.PUBLIC, output_format)
     supp_set_url = utils.get_wgs_ftp_url(prefix, utils.SUPPRESSED, output_format)
-    success = utils.get_ftp_file(public_set_url, dest_dir)
+    success = utils.get_ftp_file(public_set_url, dest_dir, handler)
     if not success:
-        success = utils.get_ftp_file(supp_set_url, dest_dir)
+        success = utils.get_ftp_file(supp_set_url, dest_dir, handler)
     if not success:
         print ('No WGS set file available for {0}, format {1}'.format(accession, output_format))
         print ('Please contact ENA (datasubs@ebi.ac.uk) if you feel this set should be available')
 
-def download_unversioned_wgs(dest_dir, accession, output_format):
+def download_unversioned_wgs(dest_dir, accession, output_format, handler=None):
     prefix = accession[:4]
     if output_format is None:
         output_format = utils.EMBL_FORMAT
     public_set_url = utils.get_nonversioned_wgs_ftp_url(prefix, utils.PUBLIC, output_format)
     if public_set_url is not None:
-        utils.get_ftp_file(public_set_url, dest_dir)
+        utils.get_ftp_file(public_set_url, dest_dir, handler)
     else:
         supp_set_url = utils.get_nonversioned_wgs_ftp_url(prefix, utils.SUPPRESSED, output_format)
         if supp_set_url is not None:
-            utils.get_ftp_file(supp_set_url, dest_dir)
+            utils.get_ftp_file(supp_set_url, dest_dir, handler)
         else:
             print ('No WGS set file available for {0}, format {1}'.format(accession, output_format))
             print ('Please contact ENA (datasubs@ebi.ac.uk) if you feel this set should be available')

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -25,6 +25,11 @@ import os
 import ssl
 import subprocess
 import sys
+import urllib
+import pexpect
+import time
+import shlex
+import json
 import urllib.request as urlrequest
 import xml.etree.ElementTree as ElementTree
 
@@ -279,11 +284,12 @@ def append_record(url, dest_file):
     except Exception:
         return False
 
-def get_ftp_file(ftp_url, dest_dir):
+def get_ftp_file(ftp_url, dest_dir, handler=None):
     try:
         filename = ftp_url.split('/')[-1]
         dest_file = os.path.join(dest_dir, filename)
-        urlrequest.urlretrieve(ftp_url, dest_file)
+        response = urllib.urlopen(ftp_url)
+        chunk_read(response, file_handle=dest_file, handler=handler)
         return True
     except Exception as e:
         print ("Error with FTP transfer: {0}".format(e))
@@ -306,12 +312,14 @@ def get_md5(filepath):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
-def check_md5(filepath, expected_md5):
+def check_md5(filepath, expected_md5, handler):
     generated_md5 = get_md5(filepath)
     if expected_md5 != generated_md5:
-        print ('MD5 mismatch for downloaded file ' + filepath + '. Deleting file')
-        print ('generated md5', generated_md5)
-        print ('expected md5', expected_md5)
+        if not handler:
+            handler=sys.stdout.write
+        handler('MD5 mismatch for downloaded file ' + filepath + '. Deleting file')
+        handler('Generated md5: %s' % generated_md5)
+        handler('Expected md5: %s' % expected_md5)
         os.remove(filepath)
         return False
     return True
@@ -326,23 +334,24 @@ def file_exists(file_url, dest_dir, md5):
             return True
     return False
 
-def get_ftp_file_with_md5_check(ftp_url, dest_dir, md5):
+def get_ftp_file_with_md5_check(ftp_url, dest_dir, md5, handler=None):
     try:
         filename = ftp_url.split('/')[-1]
         dest_file = os.path.join(dest_dir, filename)
-        urlrequest.urlretrieve(ftp_url, dest_file)
-        return check_md5(dest_file, md5)
+        response = urllib.urlopen(ftp_url)
+        chunk_read(response, file_handle=dest_file, handler=handler)
+        return check_md5(dest_file, md5, handler=handler)
     except Exception as e:
         sys.stderr.write("Error with FTP transfer: {0}\n".format(e))
         return False
 
-def get_aspera_file_with_md5_check(aspera_url, dest_dir, md5):
+def get_aspera_file_with_md5_check(aspera_url, dest_dir, md5, handler=None):
     try:
         filename = aspera_url.split('/')[-1]
         dest_file = os.path.join(dest_dir, filename)
-        success = asperaretrieve(aspera_url, dest_dir, dest_file)
+        success = asperaretrieve(aspera_url, dest_dir, dest_file, handler=handler)
         if success:
-            return check_md5(dest_file, md5)
+            return check_md5(dest_file, md5, handler=handler)
         return False
     except Exception as e:
         sys.stderr.write("Error with Aspera transfer: {0}\n".format(e))
@@ -404,22 +413,67 @@ def asperaretrieve(url, dest_dir, dest_file, handler=None):
             key=ASPERA_PRIVATE_KEY,
             speed=ASPERA_SPEED,
         )
-        #print(aspera_line)
-        #subprocess.call(aspera_line, shell=True) # this blocks so we're fine to wait and return True
-        _do_aspera_transfer(aspera_line, handler)
+        _do_aspera_pexpect(aspera_line, handler)
         return True
     except Exception as e:
         sys.stderr.write("Error with Aspera transfer: {0}\n".format(e))
         return False
 
+def _do_aspera_pexpect(cmd, handler):
+    thread = pexpect.spawn(cmd, timeout=None)
+    cpl = thread.compile_pattern_list([pexpect.EOF, '(.+)'])
+    started = 0
+
+    while True:
+        i = thread.expect_list(cpl, timeout=None)
+        if i == 0:
+            if started == 0:
+                if handler and callable(handler):
+                    handler("Error initiating transfer")
+                else:
+                    sys.stderr.write("Error initiating transfer")
+            break
+        elif i == 1:
+            started = 1
+            output = dict()
+            pexp_match = thread.match.group(1)
+            prev_file = ''
+            tokens_to_match = ["Mb/s"]
+            units_to_match = ["KB", "MB", "GB"]
+            rates_to_match = ["Kb/s", "kb/s", "Mb/s", "mb/s", "Gb/s", "gb/s"]
+            end_of_transfer = False
+            if any(tm in pexp_match.decode("utf-8") for tm in tokens_to_match):
+                tokens = pexp_match.decode("utf-8").split(" ")
+                if 'ETA' in tokens:
+                    pct_completed = [x for x in tokens if len(x) > 1 and x[-1] == '%']
+                    if pct_completed:
+                        output["pct_completed"] = pct_completed[0][:-1]
+
+                        bytes_transferred = [x for x in tokens if len(x) > 2 and x[-2:] in units_to_match]
+                        if bytes_transferred:
+                            output["bytes_transferred"] = bytes_transferred[0]
+
+                        transfer_rate = [x for x in tokens if len(x) > 4 and x[-4:] in rates_to_match]
+                        if transfer_rate:
+                            output["transfer_rate"] = transfer_rate[0]
+
+                        if handler and callable(handler):
+                            handler(json.dumps(output))
+                        else:
+                            sys.stdout.write("%s%% transferred, %s, %s\n" % (output["pct_completed"], output["bytes_transferred"], output["transfer_rate"]))
+    thread.close()
+
 def _do_aspera_transfer(cmd, handler):
-    p = Popen(cmd, stdout=PIPE, bufsize=1)
+    p = Popen(shlex.split(cmd),
+              stdout=PIPE,
+              stderr=STDOUT,
+              bufsize=1)
     with p.stdout:
         for line in iter(p.stdout.readline, b''):
             if handler and callable(handler):
                 handler(line)
             else:
-                print line,
+                sys.stdout.write(line),
     p.wait()
     pass
 
@@ -599,3 +653,53 @@ def is_empty_dir(target_dir):
 def print_error():
     sys.stderr.write('ERROR: Something unexpected went wrong please try again.\n')
     sys.stderr.write('If problem persists, please contact datasubs@ebi.ac.uk for assistance.\n')
+
+def chunk_report(f, bytes_so_far, chunk_size, total_size, handler=None):
+    global start_time
+    if bytes_so_far == chunk_size:
+        start_time = time.time()
+        return
+    duration = time.time() - start_time
+    progress_size = int(bytes_so_far)
+    speed = int(progress_size / ((1024 * 1024) * duration))
+    percent = int(progress_size * 100 /total_size)
+    line = "\r%s: %0.f%%, %d MB, %d MB/s" % (f, percent, progress_size / (1024 * 1024), speed)
+
+    if handler and callable(handler):
+        handler(line)
+    else:
+        sys.stdout.write(line)
+
+    if bytes_so_far >= total_size:
+        if handler and callable(handler):
+            handler('\n')
+        else:
+            sys.stdout.write('\n')
+
+def chunk_read(response, file_handle, chunk_size=104857, tick_rate=10, report_hook=chunk_report, handler=None):
+    total_size = response.info().getheader('Content-Length').strip()
+    bytes_so_far = 0
+
+    with open(file_handle, 'wb') as f:
+        base = os.path.basename(file_handle)
+        if total_size is None: # cannot chunk - no content length
+            f.write(response.content)
+        else:
+            tick = 0
+            total_size = int(total_size)
+            while 1:
+                chunk = response.read(chunk_size)
+                bytes_so_far += len(chunk)
+
+                if not chunk:
+                    break
+
+                f.write(chunk)
+
+                if report_hook:
+                    if tick == 0 or tick % int(tick_rate) == 0:
+                        tick = 0
+                        report_hook(base, bytes_so_far, chunk_size, total_size, handler)
+                tick += 1
+
+    return bytes_so_far


### PR DESCRIPTION
I haven't implemented the "queue" or "file" handlers yet, but here's a basic implementation of passing a handler function to those functions that would have otherwise just printed to stdout. Previously, especially for aspera transfers, the output is swallowed and can't be hoovered up by a process that watches stdout, so progress can't be monitored in any situation other than running the scripts on the command line. 

For example, in a Django app, the aspera progress output wasn't discoverable by a websocket. Now, pexpect is used to gather up the output produced by aspera at each tick, and can be outputted to stdout as text or a JSON fragment that can be used in a webapp.

It could do with a bit more work, but I hope it's useful!