### PR TITLE
minor fix to avoid escaping the colon character in the url

### DIFF
--- a/python3/readGet.py
+++ b/python3/readGet.py
@@ -53,7 +53,7 @@ def attempt_file_download(file_url, dest_dir, md5, aspera):
     return utils.get_ftp_file('ftp://' + file_url, dest_dir)
 
 def download_file(file_url, dest_dir, md5, aspera):
-    file_url = urlparse.quote(file_url)
+    file_url = urlparse.quote(file_url, safe='/:')
     if utils.file_exists(file_url, dest_dir, md5):
         return
     success = attempt_file_download(file_url, dest_dir, md5, aspera)


### PR DESCRIPTION
I ran into a bug while attempting to downloading with Aspera where the command to `urlparse.quote(file_url)` was escaping the colon (':') in the url and replacing it with "%3A" - for example if the url I was trying to download a file from was `fasp.sra.ebi.ac.uk:/vol1/fastq/ERR172/002/ERR1729192/ERR1729192.fastq.gz`, after the call to the function, it would change to `fasp.sra.ebi.ac.uk%3A/vol1/fastq/ERR172/002/ERR1729192/ERR1729192.fastq.gz`, thus resulting in download failures. I think the colon is pretty specific to the Aspera urls, so perhaps this bug wasn't caught before. I just added the colon as a "safe" character as per the Python documentation on the function, and I hope it doesn't break with other potential urls that are beyond my use case. 