### PR TITLE
no ssl needs to be passed into the request, python will handle that automatically

### DIFF
--- a/python3/utils.py
+++ b/python3/utils.py
@@ -22,7 +22,6 @@ import ftplib
 import hashlib
 import re
 import os
-import ssl
 import subprocess
 import sys
 import urllib.request as urlrequest
@@ -472,8 +471,7 @@ def get_nonversioned_wgs_ftp_url(wgs_set, status, output_format):
 
 def get_report_from_portal(url):
     request = urlrequest.Request(url)
-    gcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-    response = urlrequest.urlopen(request, context=gcontext)
+    response = urlrequest.urlopen(request)
     if response.status == 200:
         return response
     elif response.status == 204:


### PR DESCRIPTION
all along the reason for getting those SSL errors is that the module is used incorrectly and is forcing what I belive is an outdated and incorrect protocol.

there should be no need to pass protocols into the request. 

(related question, is this software still used at ENA, I would be willing to write a nicer command-line interface for it, but not if this is abandonware)