### PR TITLE
RT662185: Issue with enaDataGet

### DIFF
--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -18,7 +18,6 @@
 #
 
 import argparse
-import os
 import sys
 
 import sequenceGet
@@ -27,9 +26,10 @@ import readGet
 import utils
 import traceback
 
+
 def set_parser():
     parser = argparse.ArgumentParser(prog='enaDataGet',
-                                     description = 'Download data for a given accession')
+                                     description='Download data for a given accession')
     parser.add_argument('accession', help="""Sequence, coding, assembly, run, experiment or
                                         analysis accession or WGS prefix (LLLLVV) to download """)
     parser.add_argument('-f', '--format', default=None,
@@ -53,16 +53,18 @@ def set_parser():
     parser.add_argument('-a', '--aspera', action='store_true',
                         help='Use the aspera command line client to download, instead of FTP.')
     parser.add_argument('-as', '--aspera-settings', default=None,
-                    help="""Use the provided settings file, will otherwise check
+                        help="""Use the provided settings file, will otherwise check
                         for environment variable or default settings file location.""")
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.5.3')
     return parser
 
+
 def check_availability(accession, output_format):
     if not utils.is_available(accession, output_format):
         sys.stderr.write(
-        'ERROR: Record does not exist or is not available for accession provided\n')
+            'ERROR: Record does not exist or is not available for accession provided\n')
         sys.exit(1)
+
 
 if __name__ == '__main__':
     parser = set_parser()
@@ -117,7 +119,7 @@ if __name__ == '__main__':
         else:
             sys.stderr.write('ERROR: Invalid accession provided\n')
             sys.exit(1)
-        print ('Completed')
+        print('Completed')
     except Exception:
         traceback.print_exc()
         utils.print_error()

--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -102,12 +102,7 @@ if __name__ == '__main__':
                 output_format = sequenceGet.get_default_format()
             check_availability(accession, output_format)
             sequenceGet.download_sequence(dest_dir, accession, output_format, expanded)
-        elif utils.is_analysis(accession):
-            if output_format is not None:
-                readGet.check_read_format(output_format)
-            check_availability(accession, output_format)
-            readGet.download_files(accession, output_format, dest_dir, fetch_meta, aspera)
-        elif utils.is_run(accession) or utils.is_experiment(accession) or utils.is_sample(accession):
+        elif utils.is_analysis(accession) or utils.is_run(accession) or utils.is_experiment(accession) or utils.is_sample(accession):
             if output_format is not None:
                 readGet.check_read_format(output_format)
             check_availability(accession, output_format)

--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -47,9 +47,6 @@ def set_parser():
                         help='Expand CON scaffolds when downloading embl format (default is false)')
     parser.add_argument('-m', '--meta', action='store_true',
                         help='Download read or analysis XML in addition to data files (default is false)')
-    parser.add_argument('-i', '--index', action='store_true',
-                        help="""Download CRAM index files with submitted CRAM files, if any (default is false).
-                            This flag is ignored for fastq and sra format options. """)
     parser.add_argument('-a', '--aspera', action='store_true',
                         help='Use the aspera command line client to download, instead of FTP.')
     parser.add_argument('-as', '--aspera-settings', default=None,
@@ -77,7 +74,6 @@ if __name__ == '__main__':
     extract_wgs = args.extract_wgs
     expanded = args.expanded
     fetch_meta = args.meta
-    fetch_index = args.index
     aspera = args.aspera
     aspera_settings = args.aspera_settings
 
@@ -110,12 +106,12 @@ if __name__ == '__main__':
             if output_format is not None:
                 readGet.check_read_format(output_format)
             check_availability(accession, output_format)
-            readGet.download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, aspera)
+            readGet.download_files(accession, output_format, dest_dir, fetch_meta, aspera)
         elif utils.is_run(accession) or utils.is_experiment(accession) or utils.is_sample(accession):
             if output_format is not None:
                 readGet.check_read_format(output_format)
             check_availability(accession, output_format)
-            readGet.download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, aspera)
+            readGet.download_files(accession, output_format, dest_dir, fetch_meta, aspera)
         else:
             sys.stderr.write('ERROR: Invalid accession provided\n')
             sys.exit(1)

--- a/python3/enaGroupGet.py
+++ b/python3/enaGroupGet.py
@@ -28,9 +28,10 @@ import utils
 import traceback
 import time
 
+
 def set_parser():
     parser = argparse.ArgumentParser(prog='enaGroupGet',
-                                     description = 'Download data for a given study or sample, or (for sequence and assembly) taxon')
+                                     description='Download data for a given study or sample, or (for sequence and assembly) taxon')
     parser.add_argument('accession', help='Study or sample accession or NCBI tax ID to fetch data for')
     parser.add_argument('-g', '--group', default='read',
                         choices=['sequence', 'wgs', 'assembly', 'read', 'analysis'],
@@ -56,12 +57,13 @@ def set_parser():
     parser.add_argument('-a', '--aspera', action='store_true',
                         help='Use the aspera command line client to download, instead of FTP.')
     parser.add_argument('-as', '--aspera-settings', default=None,
-                    help="""Use the provided settings file, will otherwise check
+                        help="""Use the provided settings file, will otherwise check
                         for environment variable or default settings file location.""")
     parser.add_argument('-t', '--subtree', action='store_true',
                         help='Include subordinate taxa (taxon subtree) when querying with NCBI tax ID (default is false)')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.5.3')
     return parser
+
 
 def download_report(group, result, accession, temp_file, subtree):
     search_url = utils.get_group_search_query(group, result, accession, subtree)
@@ -74,14 +76,15 @@ def download_report(group, result, accession, temp_file, subtree):
 
 def download_data(group, data_accession, output_format, group_dir, fetch_wgs, extract_wgs, expanded, fetch_meta, fetch_index, aspera):
     if group == utils.WGS:
-        print ('Fetching ' + data_accession[:6])
+        print('Fetching ' + data_accession[:6])
         sequenceGet.download_wgs(group_dir, data_accession[:6], output_format)
     else:
-        print ('Fetching ' + data_accession)
+        print('Fetching ' + data_accession)
         if group == utils.ASSEMBLY:
-            assemblyGet.download_assembly(group_dir, data_accession, output_format, fetch_wgs, extract_wgs, expanded, True)
+            assemblyGet.download_assembly(group_dir, data_accession, output_format, fetch_wgs, extract_wgs, expanded,
+                                          True)
         elif group in [utils.READ, utils.ANALYSIS]:
-            readGet.download_files(data_accession, output_format, group_dir, fetch_index, fetch_meta, aspera)
+            readGet.download_files(data_accession, output_format, group_dir, fetch_meta, aspera)
 
 def download_data_group(group, accession, output_format, group_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index, aspera, subtree, expanded):
     temp_file_path = os.path.join(group_dir, accession + '_temp.txt')
@@ -95,6 +98,7 @@ def download_data_group(group, accession, output_format, group_dir, fetch_wgs, e
             data_accession = line.strip()
             download_data(group, data_accession, output_format, group_dir, fetch_wgs, extract_wgs, expanded, fetch_meta, fetch_index, aspera)
     os.remove(temp_file_path)
+
 
 def download_sequence_result(dest_file, group_dir, result, accession, subtree, update_accs, expanded):
     ts = time.time()
@@ -120,15 +124,18 @@ def download_sequence_result(dest_file, group_dir, result, accession, subtree, u
     os.remove(temp_file_path)
     return update_accs
 
+
 def download_sequence_group(accession, output_format, group_dir, subtree, expanded):
-    print ('Downloading sequences')
+    print('Downloading sequences')
     update_accs = []
     dest_file_path = os.path.join(group_dir, utils.get_filename(accession + '_sequences', output_format))
     dest_file = open(dest_file_path, 'wb')
-    #sequence update
-    update_accs = download_sequence_result(dest_file, group_dir, utils.SEQUENCE_UPDATE_RESULT, accession, subtree, update_accs, expanded)
-    #sequence release
-    update_accs = download_sequence_result(dest_file, group_dir, utils.SEQUENCE_RELEASE_RESULT, accession, subtree, update_accs, expanded)
+    # sequence update
+    update_accs = download_sequence_result(dest_file, group_dir, utils.SEQUENCE_UPDATE_RESULT, accession, subtree,
+                                           update_accs, expanded)
+    # sequence release
+    update_accs = download_sequence_result(dest_file, group_dir, utils.SEQUENCE_RELEASE_RESULT, accession, subtree,
+                                           update_accs, expanded)
     dest_file.close()
 
 def download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index, aspera, subtree, expanded):
@@ -166,7 +173,7 @@ if __name__ == '__main__':
 
     if not utils.is_study(accession) and not utils.is_sample(accession) and not utils.is_taxid(accession):
         sys.stderr.write(
-         'ERROR: Invalid accession. Only sample and study/project accessions or NCBI tax ID supported\n'
+            'ERROR: Invalid accession. Only sample and study/project accessions or NCBI tax ID supported\n'
         )
         sys.exit(1)
 
@@ -187,8 +194,9 @@ if __name__ == '__main__':
         if utils.is_taxid(accession) and group in ['read', 'analysis']:
             print('Sorry, tax ID retrieval not yet supported for read and analysis')
             sys.exit(1)
-        download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index, aspera, subtree, expanded)
-        print ('Completed')
+        download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index,
+                       aspera, subtree, expanded)
+        print('Completed')
     except Exception:
         traceback.print_exc()
         utils.print_error()

--- a/python3/enaGroupGet.py
+++ b/python3/enaGroupGet.py
@@ -51,9 +51,6 @@ def set_parser():
                         help='Expand CON scaffolds when downloading embl format (default is false)')
     parser.add_argument('-m', '--meta', action='store_true',
                         help='Download read or analysis XML in addition to data files (default is false)')
-    parser.add_argument('-i', '--index', action='store_true',
-                        help="""Download CRAM index files with submitted CRAM files, if any (default is false).
-                            This flag is ignored for fastq and sra format options. """)
     parser.add_argument('-a', '--aspera', action='store_true',
                         help='Use the aspera command line client to download, instead of FTP.')
     parser.add_argument('-as', '--aspera-settings', default=None,
@@ -74,7 +71,8 @@ def download_report(group, result, accession, temp_file, subtree):
     f.flush()
     f.close()
 
-def download_data(group, data_accession, output_format, group_dir, fetch_wgs, extract_wgs, expanded, fetch_meta, fetch_index, aspera):
+
+def download_data(group, data_accession, output_format, group_dir, fetch_wgs, extract_wgs, expanded, fetch_meta, aspera):
     if group == utils.WGS:
         print('Fetching ' + data_accession[:6])
         sequenceGet.download_wgs(group_dir, data_accession[:6], output_format)
@@ -86,7 +84,9 @@ def download_data(group, data_accession, output_format, group_dir, fetch_wgs, ex
         elif group in [utils.READ, utils.ANALYSIS]:
             readGet.download_files(data_accession, output_format, group_dir, fetch_meta, aspera)
 
-def download_data_group(group, accession, output_format, group_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index, aspera, subtree, expanded):
+
+def download_data_group(group, accession, output_format, group_dir, fetch_wgs, extract_wgs, fetch_meta, aspera,
+                        subtree, expanded):
     temp_file_path = os.path.join(group_dir, accession + '_temp.txt')
     download_report(group, utils.get_group_result(group), accession, temp_file_path, subtree)
     header = True
@@ -96,7 +96,8 @@ def download_data_group(group, accession, output_format, group_dir, fetch_wgs, e
                 header = False
                 continue
             data_accession = line.strip()
-            download_data(group, data_accession, output_format, group_dir, fetch_wgs, extract_wgs, expanded, fetch_meta, fetch_index, aspera)
+            download_data(group, data_accession, output_format, group_dir, fetch_wgs, extract_wgs, expanded, fetch_meta,
+                          aspera)
     os.remove(temp_file_path)
 
 
@@ -138,13 +139,17 @@ def download_sequence_group(accession, output_format, group_dir, subtree, expand
                                            update_accs, expanded)
     dest_file.close()
 
-def download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index, aspera, subtree, expanded):
+
+def download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, aspera,
+                   subtree, expanded):
     group_dir = os.path.join(dest_dir, accession)
     utils.create_dir(group_dir)
     if group == utils.SEQUENCE:
         download_sequence_group(accession, output_format, group_dir, subtree, expanded)
     else:
-        download_data_group(group, accession, output_format, group_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index, aspera, subtree, expanded)
+        download_data_group(group, accession, output_format, group_dir, fetch_wgs, extract_wgs, fetch_meta, aspera,
+                            subtree, expanded)
+
 
 if __name__ == '__main__':
     parser = set_parser()
@@ -158,7 +163,6 @@ if __name__ == '__main__':
     extract_wgs = args.extract_wgs
     expanded = args.expanded
     fetch_meta = args.meta
-    fetch_index = args.index
     aspera = args.aspera
     aspera_settings = args.aspera_settings
     subtree = args.subtree
@@ -168,13 +172,12 @@ if __name__ == '__main__':
 
     if not utils.is_available(accession, output_format):
         sys.stderr.write('ERROR: Study/sample does not exist or is not available for accession provided.\n')
-        sys.stderr.write('If you believe that it should be, please contact ENA (https://www.ebi.ac.uk/ena/browser/support) for assistance.\n')
+        sys.stderr.write('If you believe that it should be, please contact ENA ('
+                         'https://www.ebi.ac.uk/ena/browser/support) for assistance.\n')
         sys.exit(1)
 
     if not utils.is_study(accession) and not utils.is_sample(accession) and not utils.is_taxid(accession):
-        sys.stderr.write(
-            'ERROR: Invalid accession. Only sample and study/project accessions or NCBI tax ID supported\n'
-        )
+        sys.stderr.write('ERROR: Invalid accession. Only sample and study/project accessions or NCBI tax ID supported\n')
         sys.exit(1)
 
     if output_format is None:
@@ -194,8 +197,8 @@ if __name__ == '__main__':
         if utils.is_taxid(accession) and group in ['read', 'analysis']:
             print('Sorry, tax ID retrieval not yet supported for read and analysis')
             sys.exit(1)
-        download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, fetch_index,
-                       aspera, subtree, expanded)
+        download_group(accession, group, output_format, dest_dir, fetch_wgs, extract_wgs, fetch_meta, aspera, subtree,
+                       expanded)
         print('Completed')
     except Exception:
         traceback.print_exc()

--- a/python3/readGet.py
+++ b/python3/readGet.py
@@ -98,7 +98,7 @@ def download_files(accession, output_format, dest_dir, fetch_meta, aspera):
     lines = utils.download_report_from_portal(search_url)
 
     for line in lines[1:]:
-        data_accession, filelist, md5list, indexlist = utils.parse_file_search_result_line(
+        data_accession, filelist, md5list = utils.parse_file_search_result_line(
             line, accession, output_format)
         # create run directory if downloading all data for an experiment
         if is_experiment:
@@ -121,9 +121,6 @@ def download_files(accession, output_format, dest_dir, fetch_meta, aspera):
             md5 = md5list[i]
             if file_url != '':
                 download_file(file_url, target_dir, md5, aspera)
-        for index_file in indexlist:
-            if index_file != '':
-                download_file(index_file, target_dir, None, aspera)
     if utils.is_empty_dir(target_dir):
         print('Deleting directory ' + os.path.basename(target_dir))
         os.rmdir(target_dir)

--- a/python3/readGet.py
+++ b/python3/readGet.py
@@ -19,11 +19,10 @@
 
 import os
 import sys
-import argparse
-import tempfile
 import urllib.parse as urlparse
 
 import utils
+
 
 def check_read_format(output_format):
     if output_format not in [utils.SUBMITTED_FORMAT, utils.FASTQ_FORMAT, utils.SRA_FORMAT]:
@@ -32,13 +31,15 @@ def check_read_format(output_format):
         )
         sys.exit(1)
 
+
 def check_analysis_format(output_format):
     if output_format != utils.SUBMITTED_FORMAT:
         sys.stderr.write(
             'ERROR: Invalid format. Please select a valid format for this accession: {0}\n'.format(
-            utils.SUBMITTED_FORMAT)
+                utils.SUBMITTED_FORMAT)
         )
         sys.exit(1)
+
 
 def attempt_file_download(file_url, dest_dir, md5, aspera):
     if md5 is not None:
@@ -54,6 +55,7 @@ def attempt_file_download(file_url, dest_dir, md5, aspera):
     file_url = urlparse.quote(file_url)
     return utils.get_ftp_file('ftp://' + file_url, dest_dir)
 
+
 def download_file(file_url, dest_dir, md5, aspera):
     if utils.file_exists(file_url, dest_dir, md5):
         return
@@ -63,8 +65,10 @@ def download_file(file_url, dest_dir, md5, aspera):
     if not success:
         print('Failed to download file after two attempts')
 
+
 def download_meta(accession, dest_dir):
     utils.download_record(dest_dir, accession, utils.XML_FORMAT)
+
 
 def download_experiment_meta(run_accession, dest_dir):
     search_url = utils.get_experiment_search_query(run_accession)
@@ -107,9 +111,9 @@ def download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, 
             download_meta(data_accession, target_dir)
         if len(filelist) == 0:
             if output_format is None:
-                print ('No files available for {0}'.format(data_accession))
+                print('No files available for {0}'.format(data_accession))
             else:
-                print ('No files of format {0} for {1}'.format(output_format, data_accession))
+                print('No files of format {0} for {1}'.format(output_format, data_accession))
             continue
         for i in range(len(filelist)):
             file_url = filelist[i]

--- a/python3/readGet.py
+++ b/python3/readGet.py
@@ -82,7 +82,8 @@ def download_experiment_meta(run_accession, dest_dir):
         break
     download_meta(experiment_accession, dest_dir)
 
-def download_files(accession, output_format, dest_dir, fetch_index, fetch_meta, aspera):
+
+def download_files(accession, output_format, dest_dir, fetch_meta, aspera):
     accession_dir = os.path.join(dest_dir, accession)
     utils.create_dir(accession_dir)
     # download experiment xml

--- a/python3/sequenceGet.py
+++ b/python3/sequenceGet.py
@@ -18,7 +18,6 @@
 #
 
 import sys
-import argparse
 
 import utils
 
@@ -30,16 +29,19 @@ def write_record(dest_file, accession, output_format, expanded=False):
         url = url + '?expanded=true'
     return utils.write_record(url, dest_file)
 
+
 def download_sequence(dest_dir, accession, output_format, expanded):
     success = utils.download_record(dest_dir, accession, output_format, expanded)
     if not success:
-        print ('Unable to fetch file for {0}, format {1}'.format(accession, output_format))
+        print('Unable to fetch file for {0}, format {1}'.format(accession, output_format))
+
 
 def download_wgs(dest_dir, accession, output_format):
     if utils.is_unversioned_wgs_set(accession):
         return download_unversioned_wgs(dest_dir, accession, output_format)
     else:
         return download_versioned_wgs(dest_dir, accession, output_format)
+
 
 def download_versioned_wgs(dest_dir, accession, output_format):
     prefix = accession[:6]
@@ -49,8 +51,9 @@ def download_versioned_wgs(dest_dir, accession, output_format):
     if not success:
         success = utils.get_ftp_file(supp_set_url, dest_dir)
     if not success:
-        print ('No WGS set file available for {0}, format {1}'.format(accession, output_format))
-        print ('Please contact ENA (https://www.ebi.ac.uk/ena/browser/support) if you feel this set should be available')
+        print('No WGS set file available for {0}, format {1}'.format(accession, output_format))
+        print('Please contact ENA (https://www.ebi.ac.uk/ena/browser/support) if you feel this set should be available')
+
 
 def download_unversioned_wgs(dest_dir, accession, output_format):
     prefix = accession[:4]
@@ -62,14 +65,17 @@ def download_unversioned_wgs(dest_dir, accession, output_format):
         if supp_set_url is not None:
             utils.get_ftp_file(supp_set_url, dest_dir)
         else:
-            print ('No WGS set file available for {0}, format {1}'.format(accession, output_format))
-            print ('Please contact ENA (https://www.ebi.ac.uk/ena/browser/support) if you feel this set should be available')
+            print('No WGS set file available for {0}, format {1}'.format(accession, output_format))
+            print('Please contact ENA (https://www.ebi.ac.uk/ena/browser/support) if you feel this set should be '
+                  'available')
+
 
 def check_format(output_format):
     allowed_formats = [utils.EMBL_FORMAT, utils.FASTA_FORMAT, utils.MASTER_FORMAT]
     if output_format not in allowed_formats:
         sys.stderr.write('Please select a valid format for this accession: {0}\n'.format(allowed_formats))
         sys.exit(1)
+
 
 def get_default_format():
     return utils.EMBL_FORMAT

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -532,13 +532,13 @@ def download_report_from_portal(url):
 def get_accession_query(accession):
     query = 'query='
     if is_run(accession):
-        query += 'run_accession="{0}"'.format(accession)
+        query += 'run_accession=%22{0}%22'.format(accession)
     elif is_experiment(accession):
-        query += 'experiment_accession="{0}"'.format(accession)
+        query += 'experiment_accession=%22{0}%22'.format(accession)
     elif is_analysis(accession):
-        query += 'analysis_accession="{0}"'.format(accession)
+        query += 'analysis_accession=%22{0}%22'.format(accession)
     elif is_sample(accession):
-        query += 'sample_accession="{0}"'.format(accession)
+        query += 'sample_accession=%22{0}%22'.format(accession)
     return query
 
 
@@ -620,13 +620,13 @@ def create_dir(dir_path):
 def get_group_query(accession, subtree):
     query = 'query='
     if is_primary_study(accession):
-        query += 'study_accession="{0}"'.format(accession)
+        query += 'study_accession=%22{0}%22'.format(accession)
     elif is_secondary_study(accession):
-        query += 'secondary_study_accession="{0}"'.format(accession)
+        query += 'secondary_study_accession=%22{0}%22'.format(accession)
     elif is_primary_sample(accession):
-        query += 'sample_accession="{0}"'.format(accession)
+        query += 'sample_accession=%22{0}%22'.format(accession)
     elif is_secondary_sample(accession):
-        query += 'secondary_sample_accession="{0}"'.format(accession)
+        query += 'secondary_sample_accession=%22{0}%22'.format(accession)
     elif is_taxid(accession):
         if subtree:
             query += 'tax_tree({0})'.format(accession)
@@ -663,7 +663,7 @@ def get_group_search_query(group, result, accession, subtree):
 
 
 def get_experiment_search_query(run_accession):
-    return PORTAL_SEARCH_BASE + 'query=run_accession="' + run_accession + '"' \
+    return PORTAL_SEARCH_BASE + 'query=run_accession=%22' + run_accession + '%22' \
         + '&result=read_run&fields=experiment_accession&limit=0'
 
 

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -91,7 +91,6 @@ SEQUENCE_RELEASE_RESULT = 'result=sequence_release'
 FASTQ_FIELD = 'fastq_ftp'
 SUBMITTED_FIELD = 'submitted_ftp'
 SRA_FIELD = 'sra_ftp'
-INDEX_FIELD = 'cram_index_ftp'
 FASTQ_MD5_FIELD = 'fastq_md5'
 SUBMITTED_MD5_FIELD = 'submitted_md5'
 SRA_MD5_FIELD = 'sra_md5'
@@ -99,7 +98,6 @@ INDEX_MD5_FIELD = None
 FASTQ_ASPERA_FIELD = 'fastq_aspera'
 SUBMITTED_ASPERA_FIELD = 'submitted_aspera'
 SRA_ASPERA_FIELD = 'sra_aspera'
-INDEX_ASPERA_FIELD = 'cram_index_aspera'
 
 sequence_pattern_1 = re.compile('^[A-Z]{1}[0-9]{5}(\.[0-9]+)?$')
 sequence_pattern_2 = re.compile('^[A-Z]{2}[0-9]{6}(\.[0-9]+)?$')
@@ -549,7 +547,6 @@ def get_ftp_file_fields(accession):
     fields += SUBMITTED_FIELD + ',' + SUBMITTED_MD5_FIELD
     if is_analysis(accession):
         return fields
-    fields += ',' + INDEX_FIELD
     fields += ',' + SRA_FIELD + ',' + SRA_MD5_FIELD
     fields += ',' + FASTQ_FIELD + ',' + FASTQ_MD5_FIELD
     return fields
@@ -560,7 +557,6 @@ def get_aspera_file_fields(accession):
     fields += SUBMITTED_ASPERA_FIELD + ',' + SUBMITTED_MD5_FIELD
     if is_analysis(accession):
         return fields
-    fields += ',' + INDEX_ASPERA_FIELD
     fields += ',' + SRA_ASPERA_FIELD + ',' + SRA_MD5_FIELD
     fields += ',' + FASTQ_ASPERA_FIELD + ',' + FASTQ_MD5_FIELD
     return fields
@@ -599,19 +595,18 @@ def parse_file_search_result_line(line, accession, output_format):
     sub_md5list = split_filelist(cols[2])
     if is_analysis(accession):
         return data_acc, sub_filelist, sub_md5list, []
-    indexlist = split_filelist(cols[3])
-    sra_filelist = split_filelist(cols[4])
-    sra_md5list = split_filelist(cols[5])
-    fastq_filelist = split_filelist(cols[6])
-    fastq_md5list = split_filelist(cols[7])
-    if (output_format is None and len(sub_filelist) > 0):
+    sra_filelist = split_filelist(cols[3])
+    sra_md5list = split_filelist(cols[4])
+    fastq_filelist = split_filelist(cols[5])
+    fastq_md5list = split_filelist(cols[6])
+    if output_format is None and len(sub_filelist) > 0:
         output_format = SUBMITTED_FORMAT
-    elif (output_format is None and len(sra_filelist) > 0):
+    elif output_format is None and len(sra_filelist) > 0:
         output_format = SRA_FORMAT
     elif output_format is None:
         output_format = FASTQ_FORMAT
     if output_format == SUBMITTED_FORMAT:
-        return data_acc, sub_filelist, sub_md5list, indexlist
+        return data_acc, sub_filelist, sub_md5list
     if output_format == SRA_FORMAT:
         return data_acc, sra_filelist, sra_md5list, []
     return data_acc, fastq_filelist, fastq_md5list, []

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -594,22 +594,23 @@ def parse_file_search_result_line(line, accession, output_format):
     sub_filelist = split_filelist(cols[1])
     sub_md5list = split_filelist(cols[2])
     if is_analysis(accession):
-        return data_acc, sub_filelist, sub_md5list, []
+        return data_acc, sub_filelist, sub_md5list
     sra_filelist = split_filelist(cols[3])
     sra_md5list = split_filelist(cols[4])
     fastq_filelist = split_filelist(cols[5])
     fastq_md5list = split_filelist(cols[6])
-    if output_format is None and len(sub_filelist) > 0:
-        output_format = SUBMITTED_FORMAT
-    elif output_format is None and len(sra_filelist) > 0:
-        output_format = SRA_FORMAT
-    elif output_format is None:
-        output_format = FASTQ_FORMAT
+    if output_format is None:
+        if len(sub_filelist) > 0:
+            output_format = SUBMITTED_FORMAT
+        elif len(sra_filelist) > 0:
+            output_format = SRA_FORMAT
+        else:
+            output_format = FASTQ_FORMAT
     if output_format == SUBMITTED_FORMAT:
         return data_acc, sub_filelist, sub_md5list
     if output_format == SRA_FORMAT:
-        return data_acc, sra_filelist, sra_md5list, []
-    return data_acc, fastq_filelist, fastq_md5list, []
+        return data_acc, sra_filelist, sra_md5list
+    return data_acc, fastq_filelist, fastq_md5list
 
 
 def create_dir(dir_path):

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-import base64
 import ftplib
 import hashlib
 import re
@@ -26,17 +25,15 @@ import subprocess
 import sys
 import urllib.request as urlrequest
 import requests
-import xml.etree.ElementTree as ElementTree
 import urllib.error as urlerror
 import urllib.parse as urlparse
 
 from configparser import SafeConfigParser
-from http.client import HTTPSConnection
 
-ASPERA_BIN = 'ascp' # ascp binary
-ASPERA_PRIVATE_KEY = '/path/to/aspera_dsa.openssh' # ascp private key file
-ASPERA_OPTIONS = '' # set any extra aspera options
-ASPERA_SPEED = '100M' # set aspera download speed
+ASPERA_BIN = 'ascp'  # ascp binary
+ASPERA_PRIVATE_KEY = '/path/to/aspera_dsa.openssh'  # ascp private key file
+ASPERA_OPTIONS = ''  # set any extra aspera options
+ASPERA_SPEED = '100M'  # set aspera download speed
 
 SUPPRESSED = 'suppressed'
 PUBLIC = 'public'
@@ -73,12 +70,12 @@ XML_DISPLAY = 'xml/'
 EMBL_DISPLAY = 'embl/'
 FASTA_DISPLAY = 'fasta/'
 
-READ_RESULT_ID='read_run'
-ANALYSIS_RESULT_ID='analysis'
-WGS_RESULT_ID='wgs_set'
-ASSEMBLY_RESULT_ID='assembly'
-SEQUENCE_UPDATE_ID='sequence_update'
-SEQUENCE_RELEASE_ID='sequence_release'
+READ_RESULT_ID = 'read_run'
+ANALYSIS_RESULT_ID = 'analysis'
+WGS_RESULT_ID = 'wgs_set'
+ASSEMBLY_RESULT_ID = 'assembly'
+SEQUENCE_UPDATE_ID = 'sequence_update'
+SEQUENCE_RELEASE_ID = 'sequence_release'
 
 WGS_FTP_BASE = 'ftp://ftp.ebi.ac.uk/pub/databases/ena/wgs'
 WGS_FTP_DIR = 'pub/databases/ena/wgs'
@@ -124,14 +121,18 @@ sample_pattern_3 = re.compile('^[EDS]RS[0-9]{6,}$')
 
 enaBrowserTools_path = os.path.dirname(os.path.dirname(__file__))
 
+
 def is_sequence(accession):
     return sequence_pattern_1.match(accession) or sequence_pattern_2.match(accession)
+
 
 def is_wgs_sequence(accession):
     return wgs_sequence_pattern.match(accession)
 
+
 def is_coding(accession):
     return coding_pattern.match(accession)
+
 
 def is_wgs_set(accession):
     return wgs_prefix_pattern.match(accession) \
@@ -139,40 +140,52 @@ def is_wgs_set(accession):
         or unversion_wgs_prefix_pattern.match(accession) \
         or unversion_wgs_master_pattern.match(accession)
 
+
 def is_unversioned_wgs_set(accession):
     return unversion_wgs_prefix_pattern.match(accession) \
-       or unversion_wgs_master_pattern.match(accession)
+        or unversion_wgs_master_pattern.match(accession)
+
 
 def is_run(accession):
     return run_pattern.match(accession)
 
+
 def is_experiment(accession):
     return experiment_pattern.match(accession)
+
 
 def is_analysis(accession):
     return analysis_pattern.match(accession)
 
+
 def is_assembly(accession):
     return assembly_pattern.match(accession)
 
+
 def is_study(accession):
     return study_pattern_1.match(accession) or study_pattern_2.match(accession)
+
 
 def is_sample(accession):
     return sample_pattern_1.match(accession) or sample_pattern_2.match(accession) \
         or sample_pattern_3.match(accession)
 
+
 def is_primary_study(accession):
     return study_pattern_2.match(accession)
+
 
 def is_secondary_study(accession):
     return study_pattern_1.match(accession)
 
+
 def is_primary_sample(accession):
     return sample_pattern_1.match(accession) or sample_pattern_2.match(accession)
 
+
 def is_secondary_sample(accession):
     return sample_pattern_3.match(accession)
+
 
 def is_taxid(accession):
     try:
@@ -180,6 +193,7 @@ def is_taxid(accession):
         return True
     except ValueError:
         return False
+
 
 def get_accession_type(accession):
     if is_study(accession):
@@ -202,6 +216,7 @@ def get_accession_type(accession):
         return TAXON
     return None
 
+
 def accession_format_allowed(accession, output_format, aspera):
     if is_analysis(accession):
         return output_format == SUBMITTED_FORMAT
@@ -211,6 +226,7 @@ def accession_format_allowed(accession, output_format, aspera):
         else:
             return output_format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_FIELD]
     return output_format in [EMBL_FORMAT, FASTA_FORMAT]
+
 
 def group_format_allowed(group, output_format, aspera):
     if group == ANALYSIS:
@@ -222,6 +238,7 @@ def group_format_allowed(group, output_format, aspera):
             return output_format in [SUBMITTED_FORMAT, FASTQ_FORMAT, SRA_FIELD]
     return output_format in [EMBL_FORMAT, FASTA_FORMAT]
 
+
 # assumption is that accession and format have already been vetted before this method is called
 def get_record_url(accession, output_format):
     if output_format == XML_FORMAT:
@@ -231,6 +248,7 @@ def get_record_url(accession, output_format):
     elif output_format == FASTA_FORMAT:
         return VIEW_URL_BASE + FASTA_DISPLAY + accession
     return None
+
 
 def is_available(accession, output_format):
     if is_taxid(accession):
@@ -247,11 +265,13 @@ def is_available(accession, output_format):
         return response.status_code == 200 and len(response.content) != 0
     except urlerror.URLError as e:
         if 'CERTIFICATE_VERIFY_FAILED' in str(e):
-            print ('Error verifying SSL certificate. Have you run "Install Certificates" as part of your Python3 installation?')
-            print ('This is a commonly missed step in Python3 installation on a Mac.')
-            print ('Please run the following from a terminal window (update to your Python3 version as needed):')
-            print ('open "/Applications/Python 3.6/Install Certificates.command"')
+            print('Error verifying SSL certificate. Have you run "Install Certificates" as part of your Python3 '
+                  'installation?')
+            print('This is a commonly missed step in Python3 installation on a Mac.')
+            print('Please run the following from a terminal window (update to your Python3 version as needed):')
+            print('open "/Applications/Python 3.6/Install Certificates.command"')
         raise
+
 
 def get_filename(base_name, output_format):
     if output_format == XML_FORMAT:
@@ -262,14 +282,17 @@ def get_filename(base_name, output_format):
         return base_name + FASTA_EXT
     return None
 
+
 def get_destination_file(dest_dir, accession, output_format):
     filename = get_filename(accession, output_format)
     if filename is not None:
         return os.path.join(dest_dir, filename)
     return None
 
+
 def download_single_record(url, dest_file):
-        urlrequest.urlretrieve(url, dest_file)
+    urlrequest.urlretrieve(url, dest_file)
+
 
 def download_record(dest_dir, accession, output_format, expanded=False):
     try:
@@ -282,8 +305,9 @@ def download_record(dest_dir, accession, output_format, expanded=False):
         download_single_record(url, dest_file)
         return True
     except Exception as e:
-        print ("Error downloading read record: {0}".format(e))
+        print("Error downloading read record: {0}".format(e))
         return False
+
 
 def write_record(url, dest_file):
     try:
@@ -299,6 +323,7 @@ def write_record(url, dest_file):
     except Exception:
         return False
 
+
 def get_ftp_file(ftp_url, dest_dir):
     try:
         filename = urlparse.unquote(ftp_url.split('/')[-1])
@@ -309,6 +334,7 @@ def get_ftp_file(ftp_url, dest_dir):
         sys.stderr.write("Error with FTP transfer: {0}".format(e))
         sys.stderr.write("Error with FTP transfer occurred for file: {}".format(filename))
         return False
+
 
 def get_aspera_file(aspera_url, dest_dir):
     try:
@@ -321,6 +347,7 @@ def get_aspera_file(aspera_url, dest_dir):
         sys.stderr.write("Error with FTP transfer occurred for file: {}".format(filename))
         return False
 
+
 def get_md5(filepath):
     hash_md5 = hashlib.md5()
     with open(filepath, 'rb') as f:
@@ -328,15 +355,17 @@ def get_md5(filepath):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
+
 def check_md5(filepath, expected_md5):
     generated_md5 = get_md5(filepath)
     if expected_md5 != generated_md5:
-        print ('MD5 mismatch for downloaded file ' + filepath + '. Deleting file')
-        print ('generated md5', generated_md5)
-        print ('expected md5', expected_md5)
+        print('MD5 mismatch for downloaded file ' + filepath + '. Deleting file')
+        print('generated md5', generated_md5)
+        print('expected md5', expected_md5)
         os.remove(filepath)
         return False
     return True
+
 
 def file_exists(file_url, dest_dir, md5):
     filename = urlparse.unquote(file_url.split('/')[-1])
@@ -348,6 +377,7 @@ def file_exists(file_url, dest_dir, md5):
             return True
     return False
 
+
 def get_ftp_file_with_md5_check(ftp_url, dest_dir, md5):
     try:
         filename = urlparse.unquote(ftp_url.split('/')[-1])
@@ -358,6 +388,7 @@ def get_ftp_file_with_md5_check(ftp_url, dest_dir, md5):
         sys.stderr.write("Error with FTP transfer: {0}\n".format(e))
         sys.stderr.write("Error with FTP transfer occurred for file: {}".format(filename))
         return False
+
 
 def get_aspera_file_with_md5_check(aspera_url, dest_dir, md5):
     try:
@@ -372,24 +403,26 @@ def get_aspera_file_with_md5_check(aspera_url, dest_dir, md5):
         sys.stderr.write("Error with Aspera transfer occurred for file: {}".format(filename))
         return False
 
+
 def set_aspera_variables(filepath):
     try:
         parser = SafeConfigParser()
         parser.read(filepath)
-        # set and check binary location
+        #  set and check binary location
         global ASPERA_BIN
         ASPERA_BIN = parser.get('aspera', 'ASPERA_BIN')
         if not os.path.exists(ASPERA_BIN):
-            print ('Aspera binary ({0}) does not exist. Defaulting to FTP transfer'.format(ASPERA_BIN))
+            print('Aspera binary ({0}) does not exist. Defaulting to FTP transfer'.format(ASPERA_BIN))
             return False
         if not os.access(ASPERA_BIN, os.X_OK):
-            print ('You do not have permissions to execute the aspera binary ({0}). Defaulting to FTP transfer'.format(ASPERA_BIN))
+            print('You do not have permissions to execute the aspera binary ({0}). Defaulting to FTP transfer'.format(
+                ASPERA_BIN))
             return False
         # set and check private key location
         global ASPERA_PRIVATE_KEY
         ASPERA_PRIVATE_KEY = parser.get('aspera', 'ASPERA_PRIVATE_KEY')
         if not os.path.exists(ASPERA_PRIVATE_KEY):
-            print ('Private key file ({0}) does not exist. Defaulting to FTP transfer'.format(ASPERA_PRIVATE_KEY))
+            print('Private key file ({0}) does not exist. Defaulting to FTP transfer'.format(ASPERA_PRIVATE_KEY))
             return False
         # set non-file variables
         global ASPERA_SPEED
@@ -401,6 +434,7 @@ def set_aspera_variables(filepath):
         sys.stderr.write("ERROR: cannot read aspera settings from {0}.\n".format(filepath))
         sys.stderr.write("{0}\n".format(e))
         sys.exit(1)
+
 
 def set_aspera(aspera_filepath):
     aspera = True
@@ -420,13 +454,14 @@ def set_aspera(aspera_filepath):
             aspera = False
     return aspera
 
+
 def asperaretrieve(url, dest_dir, dest_file):
     try:
-        logdir=os.path.abspath(os.path.join(dest_dir, "logs"))
-        print ('Creating', logdir)
+        logdir = os.path.abspath(os.path.join(dest_dir, "logs"))
+        print('Creating', logdir)
         create_dir(logdir)
-        aspera_line="{bin} -QT -L {logs} -l {speed} -P33001 {aspera} -i {key} era-fasp@{file} {outdir}"
-        aspera_line=aspera_line.format(
+        aspera_line = "{bin} -QT -L {logs} -l {speed} -P33001 {aspera} -i {key} era-fasp@{file} {outdir}"
+        aspera_line = aspera_line.format(
             bin=ASPERA_BIN,
             outdir=dest_dir,
             logs=logdir,
@@ -436,11 +471,12 @@ def asperaretrieve(url, dest_dir, dest_file):
             speed=ASPERA_SPEED,
         )
         print(aspera_line)
-        subprocess.call(aspera_line, shell=True) # this blocks so we're fine to wait and return True
+        subprocess.call(aspera_line, shell=True)  # this blocks so we're fine to wait and return True
         return True
     except Exception as e:
         sys.stderr.write("Error with Aspera transfer: {0}\n".format(e))
         return False
+
 
 def get_wgs_file_ext(output_format):
     if output_format == EMBL_FORMAT:
@@ -450,9 +486,11 @@ def get_wgs_file_ext(output_format):
     elif output_format == MASTER_FORMAT:
         return WGS_MASTER_EXT
 
+
 def get_wgs_ftp_url(wgs_set, status, output_format):
     base_url = WGS_FTP_BASE + '/' + status + '/' + wgs_set[:3].lower() + '/' + wgs_set
     return base_url + get_wgs_file_ext(output_format)
+
 
 def get_nonversioned_wgs_ftp_url(wgs_set, status, output_format):
     ftp_url = 'ftp.ebi.ac.uk'
@@ -469,6 +507,7 @@ def get_nonversioned_wgs_ftp_url(wgs_set, status, output_format):
     else:
         return base_url + '/' + max(files)
 
+
 def get_report_from_portal(url):
     request = urlrequest.Request(url)
     response = urlrequest.urlopen(request)
@@ -483,12 +522,14 @@ def get_report_from_portal(url):
         sys.stderr.write('ERROR: Unable to fetch data from url: ' + url + '\n')
         sys.exit(1)
 
+
 def download_report_from_portal(url):
     response = get_report_from_portal(url)
     lines = []
     for line in response:
         lines.append(line.decode('utf-8'))
     return lines
+
 
 def get_accession_query(accession):
     query = 'query='
@@ -502,6 +543,7 @@ def get_accession_query(accession):
         query += 'sample_accession="{0}"'.format(accession)
     return query
 
+
 def get_ftp_file_fields(accession):
     fields = 'fields='
     fields += SUBMITTED_FIELD + ',' + SUBMITTED_MD5_FIELD
@@ -511,6 +553,7 @@ def get_ftp_file_fields(accession):
     fields += ',' + SRA_FIELD + ',' + SRA_MD5_FIELD
     fields += ',' + FASTQ_FIELD + ',' + FASTQ_MD5_FIELD
     return fields
+
 
 def get_aspera_file_fields(accession):
     fields = 'fields='
@@ -522,11 +565,13 @@ def get_aspera_file_fields(accession):
     fields += ',' + FASTQ_ASPERA_FIELD + ',' + FASTQ_MD5_FIELD
     return fields
 
+
 def get_file_fields(accession, aspera):
     if aspera:
         return get_aspera_file_fields(accession)
     else:
         return get_ftp_file_fields(accession)
+
 
 def get_result(accession):
     if is_run(accession) or is_experiment(accession) or is_sample(accession):
@@ -534,15 +579,18 @@ def get_result(accession):
     else:  # is_analysis(accession)
         return ANALYSIS_RESULT
 
+
 def get_file_search_query(accession, aspera):
     return PORTAL_SEARCH_BASE + get_accession_query(accession) + '&' + \
         get_result(accession) + '&' + \
         get_file_fields(accession, aspera) + '&limit=0'
 
+
 def split_filelist(filelist_string):
     if filelist_string.strip() == '':
         return []
     return filelist_string.strip().split(';')
+
 
 def parse_file_search_result_line(line, accession, output_format):
     cols = line.split('\t')
@@ -568,12 +616,14 @@ def parse_file_search_result_line(line, accession, output_format):
         return data_acc, sra_filelist, sra_md5list, []
     return data_acc, fastq_filelist, fastq_md5list, []
 
+
 def create_dir(dir_path):
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 
+
 def get_group_query(accession, subtree):
-    query='query='
+    query = 'query='
     if is_primary_study(accession):
         query += 'study_accession="{0}"'.format(accession)
     elif is_secondary_study(accession):
@@ -589,6 +639,7 @@ def get_group_query(accession, subtree):
             query += 'tax_eq({0})'.format(accession)
     return query
 
+
 def get_group_fields(group):
     fields = 'fields='
     if group in [SEQUENCE, WGS, ASSEMBLY]:
@@ -598,6 +649,7 @@ def get_group_fields(group):
     elif group == ANALYSIS:
         fields += 'analysis_accession'
     return fields
+
 
 def get_group_result(group):
     if group == READ:
@@ -609,13 +661,16 @@ def get_group_result(group):
     elif group == ASSEMBLY:
         return ASSEMBLY_RESULT
 
+
 def get_group_search_query(group, result, accession, subtree):
     return PORTAL_SEARCH_BASE + get_group_query(accession, subtree) + '&' \
         + result + '&' + get_group_fields(group) + '&limit=0'
 
+
 def get_experiment_search_query(run_accession):
     return PORTAL_SEARCH_BASE + 'query=run_accession="' + run_accession + '"' \
         + '&result=read_run&fields=experiment_accession&limit=0'
+
 
 def is_empty_dir(target_dir):
     for dirpath, dirnames, files in os.walk(target_dir):
@@ -623,9 +678,12 @@ def is_empty_dir(target_dir):
             return False
     return True
 
+
 def print_error():
     sys.stderr.write('ERROR: Something unexpected went wrong please try again.\n')
-    sys.stderr.write('If problem persists, please contact ENA (https://www.ebi.ac.uk/ena/browser/support) for assistance, with the above error details.\n')
+    sys.stderr.write('If problem persists, please contact ENA (https://www.ebi.ac.uk/ena/browser/support) for '
+                     'assistance, with the above error details.\n')
+
 
 def get_divisor(record_cnt):
     if record_cnt <= 10000:
@@ -634,6 +692,7 @@ def get_divisor(record_cnt):
         return 5000
     return 10000
 
+
 def record_start_line(line, output_format):
     if output_format == FASTA_FORMAT:
         return line.startswith(b'>')
@@ -641,6 +700,7 @@ def record_start_line(line, output_format):
         return line.startswith(b'ID  ')
     else:
         return False
+
 
 def extract_acc_from_line(line, output_format):
     if output_format == FASTA_FORMAT:


### PR DESCRIPTION
1. cram fields have changed in the portal API, so I removed them from the available fields, the remaining ones are: `submitted_ftp`, `submitted_md5`, `sra_ftp`, `sra_md5`, `fastq_ftp`, `fastq_md5`
2. `urllib.request.Request()` did not convert quotation marks to `%22` which resulted in bad requests to the portal API, therefore I replaced all `"` with `%22`.
3. I formatted the files to reflect Python formatting and I removed unused libraries.