### PR TITLE
Issues82: fix configparser and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that EBI now uses HTTPS servers. This can create a problem when using Pytho
 installation step. Please run the "Install Certificates.command" command to ensure your Python 3 installation on
 the Mac can correctly authenticate against the servers. To do this, run the following from a terminal window, updating
 the Python version with the correct version of Python 3 that you have installed:
-open "/Applications/Python 3.6/Install Certificates.command"
+open "/Applications/Python 3.13/Install Certificates.command"
 
 We have had a report from a user than when Python 3 was installed using homebrew, the following code needed to be run instead:
 ```

--- a/python3/enaDataGet.py
+++ b/python3/enaDataGet.py
@@ -52,7 +52,7 @@ def set_parser():
     parser.add_argument('-as', '--aspera-settings', default=None,
                         help="""Use the provided settings file, will otherwise check
                         for environment variable or default settings file location.""")
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.7.1')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.7.2')
     return parser
 
 

--- a/python3/enaGroupGet.py
+++ b/python3/enaGroupGet.py
@@ -58,7 +58,7 @@ def set_parser():
                         for environment variable or default settings file location.""")
     parser.add_argument('-t', '--subtree', action='store_true',
                         help='Include subordinate taxa (taxon subtree) when querying with NCBI tax ID (default is false)')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.7.1')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.7.2')
     return parser
 
 

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -746,7 +746,7 @@ def print_certificate_failed_error(e):
             "Error verifying SSL certificate. Have you run \"Install Certificates\" as part of your Python3 installation?\n"
             "This is a commonly missed step in Python3 installation on a Mac.\n"
             "Please run the following from a terminal window (update to your Python3 version as needed):\n"
-            "open \"/Applications/Python 3.6/Install Certificates.command\"\n"
+            "open \"/Applications/Python 3.13/Install Certificates.command\"\n"
         )
         sys.exit(1)
     else:


### PR DESCRIPTION
1. Users raised an issue related to `ConfigParser`. We were using an older version of Python, I updated to the latest version. See: https://github.com/enasequence/enaBrowserTools/issues/82
2. I fixed the warnings coming from the regex patterns.
3. The certificate error check was only added for browser API, I added it to portal API as well now.